### PR TITLE
Temporary creative tab naming fix

### DIFF
--- a/mods/eln/Eln.java
+++ b/mods/eln/Eln.java
@@ -848,6 +848,8 @@ public class Eln {
 		recipemagnetiser();
 
 		proxy.registerRenderers();
+		
+		LanguageRegistry.instance().addStringLocalization("itemGroup.Eln", "Electrical Age");
 
 		try {
 			elnHttpServer = new ElnHttpServer();


### PR DESCRIPTION
This should fix the localisation problem with the Creative Tab naming.
A better solution needs to be done.
