### PR TITLE
Make achievements rely on unlocalized names instead.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ eula.txt
 *.properties
 usernamecache.json
 options.txt
+world
+*.json
 
 # IntelliJ
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,12 @@ build
 eclipse
 logs
 config
+saves
+crash-reports
+eula.txt
+*.properties
+usernamecache.json
+options.txt
 
 # IntelliJ
 .idea

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Source code :
 - metc (website and wiki)
 - DrummingFish (GUI text parsing, testing)
 - TheBroBeans (mod promotion)
+- bloxgate (some achievement fixes; minor tweaks)
 
 ## DEPENDENCIES
 "modbus4j" 1.1 must be added in java path of eclipse project. (Gradle branch requires no setup)

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 
 apply plugin: 'forge'
 
-version = "1.9_r47"
+version = "TEST"
 group= "com.Miaou.Eln" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "ElectricalAge_BETA"
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 
 apply plugin: 'forge'
 
-version = "TEST"
+version = "1.0"
 group= "com.Miaou.Eln" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "ElectricalAge_BETA"
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 
 apply plugin: 'forge'
 
-version = "1.0"
+version = "1.9_r47"
 group= "com.Miaou.Eln" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "ElectricalAge_BETA"
 

--- a/src/main/java/assets/eln/lang/en_US.lang
+++ b/src/main/java/assets/eln/lang/en_US.lang
@@ -3,3 +3,6 @@
 # Mod info
 mod.name=Electrical Age
 mod.desc=Electricity in your base !
+
+#Machines
+50v_macerator.name=50V Macerator

--- a/src/main/java/assets/eln/lang/fr_FR.lang
+++ b/src/main/java/assets/eln/lang/fr_FR.lang
@@ -3,3 +3,6 @@
 # Mod info
 mod.name=Electrical Age
 mod.desc=Ajoutez l'électricite dans votre base !
+
+#Machines
+50v_macerator.name=50v Macerateur

--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -797,7 +797,7 @@ public class Eln {
 				elnToOtherBlockLvu = new EnergyConverterElnToOtherBlock(desc);
 				elnToOtherBlockLvu.setCreativeTab(creativeTab).setBlockName(blockName);
 				GameRegistry.registerBlock(elnToOtherBlockLvu,SimpleNodeItem.class, blockName);
-				LanguageRegistry.addName(elnToOtherBlockLvu, name);
+				//LanguageRegistry.addName(elnToOtherBlockLvu, name);
 			}
 			{
 				String blockName = "eln." + baseName + "MVUBlock";
@@ -809,7 +809,7 @@ public class Eln {
 				elnToOtherBlockMvu = new EnergyConverterElnToOtherBlock(desc);
 				elnToOtherBlockMvu.setCreativeTab(creativeTab).setBlockName(blockName);
 				GameRegistry.registerBlock(elnToOtherBlockMvu,SimpleNodeItem.class, blockName);
-				LanguageRegistry.addName(elnToOtherBlockMvu, name);
+				//LanguageRegistry.addName(elnToOtherBlockMvu, name);
 			}
 			{
 				String blockName = "eln." + baseName + "HVUBlock";
@@ -821,7 +821,7 @@ public class Eln {
 				elnToOtherBlockHvu = new EnergyConverterElnToOtherBlock(desc);
 				elnToOtherBlockHvu.setCreativeTab(creativeTab).setBlockName(blockName);
 				GameRegistry.registerBlock(elnToOtherBlockHvu,SimpleNodeItem.class, blockName);
-				LanguageRegistry.addName(elnToOtherBlockHvu, name);
+				//LanguageRegistry.addName(elnToOtherBlockHvu, name);
 			}
 		}
 	}
@@ -843,7 +843,7 @@ public class Eln {
 			computerProbeBlock = new ComputerProbeBlock();
 			computerProbeBlock.setCreativeTab(creativeTab).setBlockName(blockName);
 			GameRegistry.registerBlock(computerProbeBlock,SimpleNodeItem.class, blockName);
-			LanguageRegistry.addName(computerProbeBlock, name);
+			//LanguageRegistry.addName(computerProbeBlock, name);
 		}
 
 	}
@@ -852,7 +852,7 @@ public class Eln {
 
 	private void registerTestBlock() {
 		/*
-		 * testBlock = new TestBlock(); testBlock.setCreativeTab(creativeTab).setBlockName("TestBlock"); GameRegistry.registerBlock(testBlock, "Eln.TestBlock"); TileEntity.addMapping(TestEntity.class, "Eln.TestEntity"); LanguageRegistry.addName(testBlock,"Test Block"); NodeManager.instance.registerUuid(TestNode.getInfoStatic().getUuid(), TestNode.class);
+		 * testBlock = new TestBlock(); testBlock.setCreativeTab(creativeTab).setBlockName("TestBlock"); GameRegistry.registerBlock(testBlock, "Eln.TestBlock"); TileEntity.addMapping(TestEntity.class, "Eln.TestEntity"); //LanguageRegistry.addName(testBlock,"Test Block"); NodeManager.instance.registerUuid(TestNode.getInfoStatic().getUuid(), TestNode.class);
 		 *
 		 * GameRegistry.registerCustomItemStack("Test Block", new ItemStack(testBlock));
 		 */
@@ -3468,28 +3468,28 @@ public class Eln {
 			helmetCopper = (ItemArmor) (new genericArmorItem(ArmorMaterial.IRON, 2, ArmourType.Helmet, "eln:textures/armor/copper_layer_1.png", "eln:textures/armor/copper_layer_2.png")).setUnlocalizedName(name).setTextureName("eln:copper_helmet").setCreativeTab(creativeTab);
 			GameRegistry.registerItem(helmetCopper, "Eln." + name);
 			GameRegistry.registerCustomItemStack(name, new ItemStack(helmetCopper));
-			LanguageRegistry.addName(helmetCopper, name);
+			//LanguageRegistry.addName(helmetCopper, name);
 		}
 		{
 			name = "Copper Chestplate";
 			plateCopper = (ItemArmor) (new genericArmorItem(ArmorMaterial.IRON, 2, ArmourType.Chestplate, "eln:textures/armor/copper_layer_1.png", "eln:textures/armor/copper_layer_2.png")).setUnlocalizedName(name).setTextureName("eln:copper_chestplate").setCreativeTab(creativeTab);
 			GameRegistry.registerItem(plateCopper, "Eln." + name);
 			GameRegistry.registerCustomItemStack(name, new ItemStack(plateCopper));
-			LanguageRegistry.addName(plateCopper, name);
+			//LanguageRegistry.addName(plateCopper, name);
 		}
 		{
 			name = "Copper Leggings";
 			legsCopper = (ItemArmor) (new genericArmorItem(ArmorMaterial.IRON, 2, ArmourType.Leggings, "eln:textures/armor/copper_layer_1.png", "eln:textures/armor/copper_layer_2.png")).setUnlocalizedName(name).setTextureName("eln:copper_leggings").setCreativeTab(creativeTab);
 			GameRegistry.registerItem(legsCopper, "Eln." + name);
 			GameRegistry.registerCustomItemStack(name, new ItemStack(legsCopper));
-			LanguageRegistry.addName(legsCopper, name);
+			//LanguageRegistry.addName(legsCopper, name);
 		}
 		{
 			name = "Copper Boots";
 			bootsCopper = (ItemArmor) (new genericArmorItem(ArmorMaterial.IRON, 2, ArmourType.Boots, "eln:textures/armor/copper_layer_1.png", "eln:textures/armor/copper_layer_2.png")).setUnlocalizedName(name).setTextureName("eln:copper_boots").setCreativeTab(creativeTab);
 			GameRegistry.registerItem(bootsCopper, "Eln." + name);
 			GameRegistry.registerCustomItemStack(name, new ItemStack(bootsCopper));
-			LanguageRegistry.addName(bootsCopper, name);
+			//LanguageRegistry.addName(bootsCopper, name);
 		}
 
 		int armorPoint;
@@ -3514,7 +3514,7 @@ public class Eln {
 			)).setUnlocalizedName(name).setTextureName("eln:ecoal_helmet").setCreativeTab(creativeTab);
 			GameRegistry.registerItem(helmetECoal, "Eln." + name);
 			GameRegistry.registerCustomItemStack(name, new ItemStack(helmetECoal));
-			LanguageRegistry.addName(helmetECoal, name);
+			//LanguageRegistry.addName(helmetECoal, name);
 		}
 		{
 			name = "E-Coal Chestplate";
@@ -3531,7 +3531,7 @@ public class Eln {
 			)).setUnlocalizedName(name).setTextureName("eln:ecoal_chestplate").setCreativeTab(creativeTab);
 			GameRegistry.registerItem(plateECoal, "Eln." + name);
 			GameRegistry.registerCustomItemStack(name, new ItemStack(plateECoal));
-			LanguageRegistry.addName(plateECoal, name);
+			//LanguageRegistry.addName(plateECoal, name);
 		}
 		{
 			name = "E-Coal Leggings";
@@ -3548,7 +3548,7 @@ public class Eln {
 			)).setUnlocalizedName(name).setTextureName("eln:ecoal_leggings").setCreativeTab(creativeTab);
 			GameRegistry.registerItem(legsECoal, "Eln." + name);
 			GameRegistry.registerCustomItemStack(name, new ItemStack(legsECoal));
-			LanguageRegistry.addName(legsECoal, name);
+			//LanguageRegistry.addName(legsECoal, name);
 		}
 		{
 			name = "E-Coal Boots";
@@ -3565,7 +3565,7 @@ public class Eln {
 			)).setUnlocalizedName(name).setTextureName("eln:ecoal_boots").setCreativeTab(creativeTab);
 			GameRegistry.registerItem(bootsECoal, "Eln." + name);
 			GameRegistry.registerCustomItemStack(name, new ItemStack(bootsECoal));
-			LanguageRegistry.addName(bootsECoal, name);
+			//LanguageRegistry.addName(bootsECoal, name);
 		}
 	}
 
@@ -3577,35 +3577,35 @@ public class Eln {
 			swordCopper = (new ItemSword(ToolMaterial.IRON)).setUnlocalizedName(name).setTextureName("eln:copper_sword").setCreativeTab(creativeTab);
 			GameRegistry.registerItem(swordCopper, "Eln." + name);
 			GameRegistry.registerCustomItemStack(name, new ItemStack(swordCopper));
-			LanguageRegistry.addName(swordCopper, name);
+			//LanguageRegistry.addName(swordCopper, name);
 		}
 		{
 			name = "Copper Hoe";
 			hoeCopper = (new ItemHoe(ToolMaterial.IRON)).setUnlocalizedName(name).setTextureName("eln:copper_hoe").setCreativeTab(creativeTab);
 			GameRegistry.registerItem(hoeCopper, "Eln." + name);
 			GameRegistry.registerCustomItemStack(name, new ItemStack(hoeCopper));
-			LanguageRegistry.addName(hoeCopper, name);
+			//LanguageRegistry.addName(hoeCopper, name);
 		}
 		{
 			name = "Copper Shovel";
 			shovelCopper = (new ItemSpade(ToolMaterial.IRON)).setUnlocalizedName(name).setTextureName("eln:copper_shovel").setCreativeTab(creativeTab);
 			GameRegistry.registerItem(shovelCopper, "Eln." + name);
 			GameRegistry.registerCustomItemStack(name, new ItemStack(shovelCopper));
-			LanguageRegistry.addName(shovelCopper, name);
+			//LanguageRegistry.addName(shovelCopper, name);
 		}
 		{
 			name = "Copper Pickaxe";
 			pickaxeCopper = new ItemPickaxeEln(ToolMaterial.IRON).setUnlocalizedName(name).setTextureName("eln:copper_pickaxe").setCreativeTab(creativeTab);
 			GameRegistry.registerItem(pickaxeCopper, "Eln." + name);
 			GameRegistry.registerCustomItemStack(name, new ItemStack(pickaxeCopper));
-			LanguageRegistry.addName(pickaxeCopper, name);
+			//LanguageRegistry.addName(pickaxeCopper, name);
 		}
 		{
 			name = "Copper Axe";
 			axeCopper = new ItemAxeEln(ToolMaterial.IRON).setUnlocalizedName(name).setTextureName("eln:copper_axe").setCreativeTab(creativeTab);
 			GameRegistry.registerItem(axeCopper, "Eln." + name);
 			GameRegistry.registerCustomItemStack(name, new ItemStack(axeCopper));
-			LanguageRegistry.addName(axeCopper, name);
+			//LanguageRegistry.addName(axeCopper, name);
 		}
 
 	}

--- a/src/main/java/mods/eln/eventhandlers/ElnFMLEventsHandler.java
+++ b/src/main/java/mods/eln/eventhandlers/ElnFMLEventsHandler.java
@@ -9,10 +9,10 @@ public class ElnFMLEventsHandler {
 
     @SubscribeEvent
     public void onCraft(ItemCraftedEvent e) {
-        /*TODO Find a better solution for getting the block (different languages will cause this not to work)
-		Isn't there a way to get a block by referencing its class? Need to look into this*/
-        if (e.crafting.getUnlocalizedName() == "50v_macerator") {
+        //Got it!
+        if (e.crafting.getUnlocalizedName().equals("50v_macerator")) {
             Eln.achNetwork.sendToServer(new AchievePacket("craft50VMacerator"));
+            System.out.println("Sending achievement packet!");
         }
     }
 }

--- a/src/main/java/mods/eln/eventhandlers/ElnFMLEventsHandler.java
+++ b/src/main/java/mods/eln/eventhandlers/ElnFMLEventsHandler.java
@@ -11,9 +11,8 @@ public class ElnFMLEventsHandler {
     public void onCraft(ItemCraftedEvent e) {
         /*TODO Find a better solution for getting the block (different languages will cause this not to work)
 		Isn't there a way to get a block by referencing its class? Need to look into this*/
-        if (e.crafting.getDisplayName() == "50V Macerator") {
+        if (e.crafting.getUnlocalizedName() == "50v_macerator") {
             Eln.achNetwork.sendToServer(new AchievePacket("craft50VMacerator"));
         }
-        System.out.println(e.crafting.getUnlocalizedName());
     }
 }

--- a/src/main/java/mods/eln/eventhandlers/ElnFMLEventsHandler.java
+++ b/src/main/java/mods/eln/eventhandlers/ElnFMLEventsHandler.java
@@ -14,5 +14,6 @@ public class ElnFMLEventsHandler {
         if (e.crafting.getDisplayName() == "50V Macerator") {
             Eln.achNetwork.sendToServer(new AchievePacket("craft50VMacerator"));
         }
+        System.out.println(e.crafting.getUnlocalizedName());
     }
 }

--- a/src/main/java/mods/eln/eventhandlers/ElnFMLEventsHandler.java
+++ b/src/main/java/mods/eln/eventhandlers/ElnFMLEventsHandler.java
@@ -9,7 +9,8 @@ public class ElnFMLEventsHandler {
 
     @SubscribeEvent
     public void onCraft(ItemCraftedEvent e) {
-        //TODO Find a better solution for getting the block (different languages will cause this not to work)
+        /*TODO Find a better solution for getting the block (different languages will cause this not to work)
+		Isn't there a way to get a block by referencing its class? Need to look into this*/
         if (e.crafting.getDisplayName() == "50V Macerator") {
             Eln.achNetwork.sendToServer(new AchievePacket("craft50VMacerator"));
         }

--- a/src/main/java/mods/eln/eventhandlers/ElnForgeEventsHandler.java
+++ b/src/main/java/mods/eln/eventhandlers/ElnForgeEventsHandler.java
@@ -1,6 +1,8 @@
 package mods.eln.eventhandlers;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import mods.eln.Eln;
 import mods.eln.achievepackets.AchievePacket;
 import mods.eln.wiki.Root;
@@ -9,6 +11,7 @@ import net.minecraftforge.client.event.GuiOpenEvent;
 public class ElnForgeEventsHandler {
 
     @SubscribeEvent
+    @SideOnly(Side.CLIENT)
     public void openGuide(GuiOpenEvent e) {
         if (e.gui instanceof Root) {
             Eln.achNetwork.sendToServer(new AchievePacket("openWiki"));

--- a/src/main/java/mods/eln/generic/GenericItemBlockUsingDamage.java
+++ b/src/main/java/mods/eln/generic/GenericItemBlockUsingDamage.java
@@ -58,6 +58,7 @@ public class GenericItemBlockUsingDamage<Descriptor extends GenericItemBlockUsin
 		ItemStack stack = new ItemStack(this, 1, damage);
 		stack.setTagCompound(descriptor.getDefaultNBT());
 		LanguageRegistry.addName(stack, descriptor.name);
+		this.setUnlocalizedName(descriptor.name.replace("", "_"));
 		descriptor.setParent(this, damage);
 	}
 

--- a/src/main/java/mods/eln/generic/GenericItemBlockUsingDamage.java
+++ b/src/main/java/mods/eln/generic/GenericItemBlockUsingDamage.java
@@ -58,7 +58,7 @@ public class GenericItemBlockUsingDamage<Descriptor extends GenericItemBlockUsin
 		ItemStack stack = new ItemStack(this, 1, damage);
 		stack.setTagCompound(descriptor.getDefaultNBT());
 		LanguageRegistry.addName(stack, descriptor.name);
-		this.setUnlocalizedName(descriptor.name.replace("", "_"));
+		this.setUnlocalizedName(descriptor.name.replace("", "_").toLowerCase());
 		descriptor.setParent(this, damage);
 	}
 

--- a/src/main/java/mods/eln/generic/GenericItemBlockUsingDamage.java
+++ b/src/main/java/mods/eln/generic/GenericItemBlockUsingDamage.java
@@ -58,7 +58,6 @@ public class GenericItemBlockUsingDamage<Descriptor extends GenericItemBlockUsin
 		ItemStack stack = new ItemStack(this, 1, damage);
 		stack.setTagCompound(descriptor.getDefaultNBT());
 		LanguageRegistry.addName(stack, descriptor.name);
-		this.setUnlocalizedName(descriptor.name.replace(" ", "_").toLowerCase());
 		descriptor.setParent(this, damage);
 	}
 

--- a/src/main/java/mods/eln/generic/GenericItemBlockUsingDamage.java
+++ b/src/main/java/mods/eln/generic/GenericItemBlockUsingDamage.java
@@ -46,7 +46,7 @@ public class GenericItemBlockUsingDamage<Descriptor extends GenericItemBlockUsin
 		subItemList.put(damage, descriptor);
 		ItemStack stack = new ItemStack(this, 1, damage);
 		stack.setTagCompound(descriptor.getDefaultNBT());
-		LanguageRegistry.addName(stack, descriptor.name);
+		//LanguageRegistry.addName(stack, descriptor.name);
 		orderList.add(damage);
 		descriptors.add(descriptor);
 		descriptor.setParent(this, damage);
@@ -57,7 +57,7 @@ public class GenericItemBlockUsingDamage<Descriptor extends GenericItemBlockUsin
 		subItemList.put(damage, descriptor);
 		ItemStack stack = new ItemStack(this, 1, damage);
 		stack.setTagCompound(descriptor.getDefaultNBT());
-		LanguageRegistry.addName(stack, descriptor.name);
+		//LanguageRegistry.addName(stack, descriptor.name);
 		descriptor.setParent(this, damage);
 	}
 
@@ -89,12 +89,12 @@ public class GenericItemBlockUsingDamage<Descriptor extends GenericItemBlockUsin
 	}
 	*/
 
-	@Override
+	/*@Override
     public String getItemStackDisplayName(ItemStack par1ItemStack) {
 		Descriptor desc = getDescriptor(par1ItemStack);
 		if(desc == null) return "Unknown";
         return desc.getName(par1ItemStack);
-    }
+    }*/
 	
 	@Override
 	public String getUnlocalizedName(ItemStack par1ItemStack){

--- a/src/main/java/mods/eln/generic/GenericItemBlockUsingDamage.java
+++ b/src/main/java/mods/eln/generic/GenericItemBlockUsingDamage.java
@@ -58,7 +58,7 @@ public class GenericItemBlockUsingDamage<Descriptor extends GenericItemBlockUsin
 		ItemStack stack = new ItemStack(this, 1, damage);
 		stack.setTagCompound(descriptor.getDefaultNBT());
 		LanguageRegistry.addName(stack, descriptor.name);
-		this.setUnlocalizedName(descriptor.name.replace("", "_").toLowerCase());
+		this.setUnlocalizedName(descriptor.name.replace(" ", "_").toLowerCase());
 		descriptor.setParent(this, damage);
 	}
 

--- a/src/main/java/mods/eln/generic/GenericItemBlockUsingDamage.java
+++ b/src/main/java/mods/eln/generic/GenericItemBlockUsingDamage.java
@@ -95,6 +95,12 @@ public class GenericItemBlockUsingDamage<Descriptor extends GenericItemBlockUsin
 		if(desc == null) return "Unknown";
         return desc.getName(par1ItemStack);
     }
+	
+	@Override
+	public String getUnlocalizedName(ItemStack par1ItemStack){
+		Descriptor desc = getDescriptor(par1ItemStack);
+		return desc.name.replaceAll("\\s+","_").toLowerCase();			
+	}
 
 	@Override
     public IIcon getIconFromDamage(int damage) {

--- a/src/main/java/mods/eln/misc/Version.java
+++ b/src/main/java/mods/eln/misc/Version.java
@@ -18,7 +18,7 @@ public final class Version {
 	 * Unique version code. Must be a String for annotations. Used to check if a
 	 * new version if available. Each update must increment this number.
 	 */
-	public final static String REVISION = "47";
+	public final static String REVISION = "48";
 
 	public final static String getVersionName() {
 		return String.format("BETA-%d.%d r%s", MAJOR, MINOR, REVISION);


### PR DESCRIPTION
This will stop them from breaking if a different language is used. Note: I'd think this is obvious but better safe than sorry: The basic research commit was just me adding some ideas to look into to the TODO statement, nothing to do with any sort of research system.
Changes made:
- Unlocalized names for some items/blocks. (Those using GenericItemBlockUsingDamage)
- Macerator achievement now uses unlocalized names
- Added macerator to US English language file
- Added myself to the contributors list in the readme :P 
- Revision number increased to 48
