### PR TITLE
Gradle script improved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 bin
 build
 eclipse
+run
 logs
 config
 

--- a/build.bat
+++ b/build.bat
@@ -1,9 +1,0 @@
-del %appdata%\.minecraft\mods\ElectricalAge*
-
-gradlew build
-
-copy build\libs\ElectricalAge_BETA-1.0.jar %appdata%\.minecraft\mods\ElectricalAge_BETA-1.x_rxx.jar
-
-echo END OF SCRIPT
-pause
-pause

--- a/build.gradle
+++ b/build.gradle
@@ -92,4 +92,18 @@ processResources {
     }
 }
 
+// Custom task to build and copy the mod Jar to the default local Minecraft folder
+task buildAndCopyJar(dependsOn: 'build', type: Copy) {
+    outputs.upToDateWhen { false } // Force to run this task
 
+    def outDir = "/tmp"
+
+    // FIXME: works only on Windows
+    if (System.getProperty("os.name").toLowerCase().contains('windows')) {
+        outDir = System.getenv("APPDATA")
+    }
+
+    from("build/libs")
+    into(outDir + "/.minecraft/mods")
+    include("*.jar")
+}

--- a/build.gradle
+++ b/build.gradle
@@ -98,12 +98,13 @@ task buildAndCopyJar(dependsOn: 'build', type: Copy) {
 
     def outDir = "/tmp"
 
-    // FIXME: works only on Windows
+    // FIXME: works not on Linux.
     if (System.getProperty("os.name").toLowerCase().contains('windows')) {
-        outDir = System.getenv("APPDATA")
+        outDir = System.getenv("APPDATA") + "/.minecraft"
+    } else if (System.getProperty("os.name").toLowerCase().contains('os x')) {
+        outDir = System.getProperty("user.home") + "/Library/Application Support/minecraft"
     }
-
     from("build/libs")
-    into(outDir + "/.minecraft/mods")
+    into(outDir + "/mods")
     include("*.jar")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -17,18 +17,25 @@ buildscript {
 
 apply plugin: 'forge'
 
-version = "1.0"
-group= "com.Miaou.Eln" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
+
+group = "com.Miaou.Eln" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "ElectricalAge_BETA"
+version = "1.0"
+
+sourceSets {
+    main {
+        java { srcDirs = ["$projectDir/src/main/java"] }
+        resources { srcDirs = ["$projectDir/src/main/java/assets/eln"] }
+    }
+}
 
 minecraft {
     version = "1.7.10-10.13.2.1291"
-    runDir = "eclipse"
-	assetDir = "eclipse/assets"
-	
-	srgExtra "PK: org/apache/commons/math3 mods/eln/libs/org/apache/commons/math3"
-	srgExtra "PK: com/serotonin mods/eln/libs/com/serotonin"
-	srgExtra "PK: gnu/io mods/eln/libs/gnu/io"
+    runDir = "run"
+
+    srgExtra "PK: org/apache/commons/math3 mods/eln/libs/org/apache/commons/math3"
+    srgExtra "PK: com/serotonin mods/eln/libs/com/serotonin"
+    srgExtra "PK: gnu/io mods/eln/libs/gnu/io"
 }
 
 
@@ -39,12 +46,12 @@ configurations {
 }
 
 dependencies {
-	external files("libs/commons-math3-3.3.jar","libs/modbus4J.jar","libs/seroUtils.jar")
+    external files("libs/commons-math3-3.3.jar", "libs/modbus4J.jar", "libs/seroUtils.jar")
 }
 
 jar {
     from { configurations.external.collect { it.isDirectory() ? it : zipTree(it) } }
-	exclude(['dan200/**','ic2/**','li/**','buildcraft/**'])
+    exclude(['dan200/**', 'ic2/**', 'li/**', 'buildcraft/**'])
 }
 
 processResources {
@@ -55,27 +62,26 @@ processResources {
     // replace stuff in mcmod.info, nothing else
     from(sourceSets.main.resources.srcDirs) {
         include 'mcmod.info'
-                
+
         // replace version and mcversion
-        expand 'version':project.version, 'mcversion':project.minecraft.version
+        expand 'version': project.version, 'mcversion': project.minecraft.version
     }
-        
+
     // copy everything else, thats not the mcmod.info
     from(sourceSets.main.resources.srcDirs) {
         exclude 'mcmod.info'
     }
-	
-	from('src/main/java'){
-		exclude '**/*.java' 
-		exclude '**/*.blend' 
-		exclude '**/*.blend1' 
-		exclude '**/*.blend2' 
-		exclude '**/*.rar' 
-		exclude '**/*.wav' 
-		exclude '**/*.m_p' 
-		exclude '**/*.ai' 
-	}
+
+    from('src/main/java') {
+        exclude '**/*.java'
+        exclude '**/*.blend'
+        exclude '**/*.blend1'
+        exclude '**/*.blend2'
+        exclude '**/*.rar'
+        exclude '**/*.wav'
+        exclude '**/*.m_p'
+        exclude '**/*.ai'
+    }
 }
 
-// Resource and asset folder path for IntelliJ
-sourceSets { main { output.resourcesDir = output.classesDir } }
+

--- a/build.gradle
+++ b/build.gradle
@@ -17,10 +17,18 @@ buildscript {
 
 apply plugin: 'forge'
 
+def getVersion() {
+    // FIXME: cannot import 'mods.eln.misc.Version' class here ?
+    def version_major = 1
+    def version_minor = 9
+    def version_revision = 47
+
+    return "$version_major.${version_minor}_r$version_revision" // 1.9_r47
+}
 
 group = "com.Miaou.Eln" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "ElectricalAge_BETA"
-version = "1.0"
+version = getVersion()
 
 sourceSets {
     main {

--- a/push.bat
+++ b/push.bat
@@ -1,5 +1,0 @@
-del %appdata%\.minecraft\mods\ElectricalAge*
-
-copy build\libs\ElectricalAge_BETA-1.0.jar %appdata%\.minecraft\mods\ElectricalAge_BETA-1.x_rxx.jar
-
-pause


### PR DESCRIPTION
- The run folder has been renamed to 'run' (replacing the 'eclipse' folder).
- The resources folder is now "asset/eln".
- New `buildAndCopyJar` custom task added to publish locally the mod jar file (only available on Windows for now).
- The task `runClient` should be fixed.

@cm0x4D could you test the new build script, especially the `runClient` task ?
