### PR TITLE
Use units in Circuts simulation

### DIFF
--- a/src/main/java/mods/eln/entity/ReplicatoCableAI.java
+++ b/src/main/java/mods/eln/entity/ReplicatoCableAI.java
@@ -15,6 +15,7 @@ import mods.eln.sim.IProcess;
 import mods.eln.sim.ITimeRemoverObserver;
 import mods.eln.sim.TimeRemover;
 import mods.eln.sim.mna.component.Resistor;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sixnode.electricalcable.ElectricalCableElement;
 import net.minecraft.entity.ai.EntityAIBase;
 import net.minecraft.pathfinding.PathEntity;
@@ -117,11 +118,11 @@ public class ReplicatoCableAI extends EntityAIBase implements ITimeRemoverObserv
 		if(distance < 2) {
 			//Utils.println("replicator on cable !");
 			double u = cable.electricalLoad.getU();
-			double nextRp = Math.pow(u / Eln.LVU, -0.3) * u * u / (50);
-			if(resistorLoad.getR() < 0.8*nextRp) {
+			Resistance nextRp = new Resistance(Math.pow(u / Eln.LVU, -0.3) * u * u / (50));
+			if(resistorLoad.getR().getValue() < 0.8*nextRp.getValue()) {
 				entity.attackEntityFrom(DamageSource.magic, 5);
 			} else {
-				entity.eatElectricity(resistorLoad.getP() * 0.05);
+				entity.eatElectricity(resistorLoad.getP().getValue() * 0.05);
 			}
 
 			resistorLoad.setR(nextRp);

--- a/src/main/java/mods/eln/item/LampDescriptor.java
+++ b/src/main/java/mods/eln/item/LampDescriptor.java
@@ -9,6 +9,7 @@ import mods.eln.Eln;
 import mods.eln.misc.IConfigSharing;
 import mods.eln.misc.Utils;
 import mods.eln.sim.mna.component.Resistor;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sixnode.lampsocket.LampSocketType;
 import mods.eln.wiki.Data;
 import net.minecraft.entity.player.EntityPlayer;
@@ -96,7 +97,7 @@ public class LampDescriptor extends GenericItemUsingDamageDescriptorUpgrade impl
 	}
 	
 	public void applyTo(Resistor resistor) {
-		resistor.setR(getR());
+		resistor.setR(new Resistance(getR()));
 	}
 	
 	@Override

--- a/src/main/java/mods/eln/signalinductor/SignalInductorDescriptor.java
+++ b/src/main/java/mods/eln/signalinductor/SignalInductorDescriptor.java
@@ -5,6 +5,7 @@ import java.util.List;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.mna.component.Inductor;
+import mods.eln.sim.mna.primitives.Inductance;
 import mods.eln.sixnode.electricalcable.ElectricalCableDescriptor;
 import mods.eln.wiki.Data;
 import net.minecraft.entity.player.EntityPlayer;
@@ -34,7 +35,7 @@ public class SignalInductorDescriptor extends SixNodeDescriptor {
 	}
 
 	public void applyTo(Inductor inductor) {
-		inductor.setL(henri);
+		inductor.setL(new Inductance(henri));
 	}
 
 	@Override

--- a/src/main/java/mods/eln/signalinductor/SignalInductorElement.java
+++ b/src/main/java/mods/eln/signalinductor/SignalInductorElement.java
@@ -49,7 +49,7 @@ public class SignalInductorElement extends SixNodeElement {
 
 	@Override
 	public String multiMeterString() {
-		return Utils.plotAmpere("I", inductor.getCurrent());
+		return Utils.plotAmpere("I", inductor.getCurrent().getValue());
 	}
 
 	@Override

--- a/src/main/java/mods/eln/sim/BatteryProcess.java
+++ b/src/main/java/mods/eln/sim/BatteryProcess.java
@@ -2,6 +2,7 @@ package mods.eln.sim;
 
 import mods.eln.misc.FunctionTable;
 import mods.eln.sim.mna.component.VoltageSource;
+import mods.eln.sim.mna.primitives.Voltage;
 import mods.eln.sim.mna.state.VoltageState;
 
 public class BatteryProcess implements IProcess {
@@ -30,11 +31,11 @@ public class BatteryProcess implements IProcess {
 	@Override
 	public void process(double time) {
 //		Utils.print("*");
-		Q -= voltageSource.getCurrent() * time;
+		Q -= voltageSource.getCurrent().getValue() * time;
 		
 		double voltage = computeVoltage();
 		
-		voltageSource.setU(voltage);
+		voltageSource.setU(new Voltage(voltage));
 		
 		/*double Cequ = (positiveLoad.getC() * negativeLoad.getC()) / (positiveLoad.getC() + negativeLoad.getC());
 		double QNeeded = (voltage - (positiveLoad.Uc - negativeLoad.Uc)) * Cequ;
@@ -124,6 +125,6 @@ public class BatteryProcess implements IProcess {
 	}
 
 	public double getDischargeCurrent() {
-		return voltageSource.getI();
+		return voltageSource.getI().getValue();
 	}
 }

--- a/src/main/java/mods/eln/sim/DiodeProcess.java
+++ b/src/main/java/mods/eln/sim/DiodeProcess.java
@@ -12,6 +12,6 @@ public class DiodeProcess implements IProcess {
 
 	@Override
 	public void process(double time) {
-		resistor.setState(resistor.getU() > 0);
+		resistor.setState(resistor.getU().getValue() > 0);
 	}
 }

--- a/src/main/java/mods/eln/sim/ElectricalConnection.java
+++ b/src/main/java/mods/eln/sim/ElectricalConnection.java
@@ -1,6 +1,7 @@
 package mods.eln.sim;
 
 import mods.eln.sim.mna.component.InterSystem;
+import mods.eln.sim.mna.primitives.Resistance;
 
 public class ElectricalConnection extends InterSystem {
 
@@ -13,7 +14,7 @@ public class ElectricalConnection extends InterSystem {
 
 	public void notifyRsChange() {
 		double R = ((ElectricalLoad) aPin).getRs() + ((ElectricalLoad) bPin).getRs();
-		setR(R);	
+		setR(new Resistance(R));
 	}
 
 	@Override

--- a/src/main/java/mods/eln/sim/ElectricalLoad.java
+++ b/src/main/java/mods/eln/sim/ElectricalLoad.java
@@ -42,7 +42,7 @@ public class ElectricalLoad extends VoltageStateLineReady {
 		double i = 0;
 		for (Component c : getConnectedComponents()) {
 			if (c instanceof Bipole && (!(c instanceof Line)))
-				i += Math.abs(((Bipole)c).getCurrent());
+				i += Math.abs(((Bipole)c).getCurrent().getValue());
 		}
 		return i * 0.5;
 	}

--- a/src/main/java/mods/eln/sim/ElectricalResistorHeatThermalLoad.java
+++ b/src/main/java/mods/eln/sim/ElectricalResistorHeatThermalLoad.java
@@ -14,6 +14,6 @@ public class ElectricalResistorHeatThermalLoad implements IProcess {
 
 	@Override
 	public void process(double time) {
-		thermalLoad.PcTemp += electricalResistor.getP();
+		thermalLoad.PcTemp += electricalResistor.getP().getValue();
 	}
 }

--- a/src/main/java/mods/eln/sim/ElectricalStackMachineProcess.java
+++ b/src/main/java/mods/eln/sim/ElectricalStackMachineProcess.java
@@ -4,6 +4,7 @@ import mods.eln.misc.Recipe;
 import mods.eln.misc.RecipesList;
 import mods.eln.misc.Utils;
 import mods.eln.sim.mna.component.Resistor;
+import mods.eln.sim.mna.primitives.Resistance;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 
@@ -79,7 +80,7 @@ public class ElectricalStackMachineProcess implements IProcess {
 	}
 
 	public double getPower() {
-		return electricalResistor.getP() * efficiency;
+		return electricalResistor.getP().getValue() * efficiency;
 	}
 	
 	public void smeltInit() {
@@ -93,13 +94,13 @@ public class ElectricalStackMachineProcess implements IProcess {
 			smeltInProcess = true;
 			energyNeeded = recipesList.getRecipe(inventory.getStackInSlot(inputSlotId)).energy;
 			energyCounter = 0.0;
-			electricalResistor.setR(resistorValue / speedUp);
+			electricalResistor.setR(new Resistance(resistorValue / speedUp));
 		}
 	}
 	
 	public void setResistorValue(double value) {
 		resistorValue = value;
-		if (smeltInProcess) electricalResistor.setR(resistorValue / speedUp);
+		if (smeltInProcess) electricalResistor.setR(new Resistance(resistorValue / speedUp));
 	}
 	
     /**

--- a/src/main/java/mods/eln/sim/RegulatorThermalLoadToElectricalResistor.java
+++ b/src/main/java/mods/eln/sim/RegulatorThermalLoadToElectricalResistor.java
@@ -1,6 +1,7 @@
 package mods.eln.sim;
 
 import mods.eln.sim.mna.component.Resistor;
+import mods.eln.sim.mna.primitives.Resistance;
 
 public class RegulatorThermalLoadToElectricalResistor extends RegulatorProcess {
 
@@ -29,9 +30,9 @@ public class RegulatorThermalLoadToElectricalResistor extends RegulatorProcess {
 		if (cmd <= 0.001) {
 			electricalResistor.highImpedance();
 		} else if (cmd >= 1.0) {
-			electricalResistor.setR(Rmin);
+			electricalResistor.setR(new Resistance(Rmin));
 		} else {
-			electricalResistor.setR(Rmin / cmd);
+			electricalResistor.setR(new Resistance(Rmin / cmd));
 		}
 	}
 }

--- a/src/main/java/mods/eln/sim/SignalRp.java
+++ b/src/main/java/mods/eln/sim/SignalRp.java
@@ -2,11 +2,12 @@ package mods.eln.sim;
 
 import mods.eln.Eln;
 import mods.eln.sim.mna.component.Resistor;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sim.mna.state.State;
 
 public class SignalRp extends Resistor {
 	public SignalRp(State aPin) {
 		super(aPin, null);
-		setR(Eln.instance.SVU / Eln.instance.SVII);
+		setR(new Resistance(Eln.instance.SVU / Eln.instance.SVII));
 	}
 }

--- a/src/main/java/mods/eln/sim/Simulator.java
+++ b/src/main/java/mods/eln/sim/Simulator.java
@@ -7,6 +7,7 @@ import cpw.mods.fml.common.gameevent.TickEvent.ServerTickEvent;
 import mods.eln.misc.Utils;
 import mods.eln.sim.mna.RootSystem;
 import mods.eln.sim.mna.component.Component;
+import mods.eln.sim.mna.primitives.Timedelta;
 import mods.eln.sim.mna.state.State;
 import mods.eln.sim.process.destruct.IDestructable;
 
@@ -72,7 +73,7 @@ public class Simulator /* ,IPacketHandler */{
 
 		FMLCommonHandler.instance().bus().register(this);
 
-		mna = new RootSystem(electricalPeriod, electricalInterSystemOverSampling);
+		mna = new RootSystem(new Timedelta(electricalPeriod), electricalInterSystemOverSampling);
 
 		slowProcessList = new ArrayList<IProcess>();
 		slowPreProcessList = new ArrayList<IProcess>();
@@ -95,7 +96,7 @@ public class Simulator /* ,IPacketHandler */{
 	public void init() {
 		nodeCount = 0;
 
-		mna = new RootSystem(electricalPeriod, electricalInterSystemOverSampling);
+		mna = new RootSystem(new Timedelta(electricalPeriod), electricalInterSystemOverSampling);
 
 		slowProcessList.clear();
 		slowPreProcessList.clear();

--- a/src/main/java/mods/eln/sim/mna/RootSystem.java
+++ b/src/main/java/mods/eln/sim/mna/RootSystem.java
@@ -6,6 +6,9 @@ import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.mna.component.*;
 import mods.eln.sim.mna.misc.IRootSystemPreStepProcess;
 import mods.eln.sim.mna.misc.ISubSystemProcessFlush;
+import mods.eln.sim.mna.primitives.Resistance;
+import mods.eln.sim.mna.primitives.Timedelta;
+import mods.eln.sim.mna.primitives.Voltage;
 import mods.eln.sim.mna.state.State;
 import mods.eln.sim.mna.state.VoltageState;
 
@@ -13,7 +16,7 @@ import java.util.*;
 
 public class RootSystem {
 
-	double dt;
+	Timedelta dt;
 	int interSystemOverSampling;
 
 	ArrayList<SubSystem> systems = new ArrayList<SubSystem>();
@@ -29,7 +32,7 @@ public class RootSystem {
 
 	ArrayList<IRootSystemPreStepProcess> processPre = new ArrayList<IRootSystemPreStepProcess>();
 
-	public RootSystem(double dt, int interSystemOverSampling) {
+	public RootSystem(Timedelta dt, int interSystemOverSampling) {
 		this.dt = dt;
 		this.interSystemOverSampling = interSystemOverSampling;
 	}
@@ -370,7 +373,7 @@ public class RootSystem {
 	}
 
 	public static void main(String[] args) {
-		RootSystem s = new RootSystem(0.1, 1);
+		RootSystem s = new RootSystem(new Timedelta(0.1), 1);
 
 		VoltageState n1, n2;
 		VoltageSource u1;
@@ -379,10 +382,10 @@ public class RootSystem {
 		s.addState(n1 = new VoltageState());
 		s.addState(n2 = new VoltageState());
 
-		s.addComponent((u1 = new VoltageSource("")).setU(1).connectTo(n1, null));
+		s.addComponent((u1 = new VoltageSource("")).setU(new Voltage(1)).connectTo(n1, null));
 
-		s.addComponent((r1 = new Resistor()).setR(10).connectTo(n1, n2));
-		s.addComponent((r2 = new Resistor()).setR(20).connectTo(n2, null));
+		s.addComponent((r1 = new Resistor()).setR(new Resistance(10)).connectTo(n1, n2));
+		s.addComponent((r2 = new Resistor()).setR(new Resistance(20)).connectTo(n2, null));
 
 		VoltageState n11, n12;
 		VoltageSource u11;
@@ -391,20 +394,20 @@ public class RootSystem {
 		s.addState(n11 = new VoltageState());
 		s.addState(n12 = new VoltageState());
 
-		s.addComponent((u11 = new VoltageSource("")).setU(1).connectTo(n11, null));
+		s.addComponent((u11 = new VoltageSource("")).setU(new Voltage(1)).connectTo(n11, null));
 
-		s.addComponent((r11 = new Resistor()).setR(10).connectTo(n11, n12));
-		s.addComponent((r12 = new Resistor()).setR(30).connectTo(n12, null));
+		s.addComponent((r11 = new Resistor()).setR(new Resistance(10)).connectTo(n11, n12));
+		s.addComponent((r12 = new Resistor()).setR(new Resistance(30)).connectTo(n12, null));
 
 		InterSystem i01;
 
-		s.addComponent((i01 = new InterSystem()).setR(10).connectTo(n2, n12));
+		s.addComponent((i01 = new InterSystem()).setR(new Resistance(10)).connectTo(n2, n12));
 
 		for (int i = 0; i < 50; i++) {
 			s.step();
 		}
 
-		s.addComponent((r13 = new Resistor()).setR(30).connectTo(n12, null));
+		s.addComponent((r13 = new Resistor()).setR(new Resistance(30)).connectTo(n12, null));
 
 		for (int i = 0; i < 50; i++) {
 			s.step();

--- a/src/main/java/mods/eln/sim/mna/component/Bipole.java
+++ b/src/main/java/mods/eln/sim/mna/component/Bipole.java
@@ -1,5 +1,7 @@
 package mods.eln.sim.mna.component;
 
+import mods.eln.sim.mna.primitives.Current;
+import mods.eln.sim.mna.primitives.Voltage;
 import mods.eln.sim.mna.state.State;
 
 public abstract class Bipole extends Component {
@@ -44,13 +46,13 @@ public abstract class Bipole extends Component {
 		return new State[]{aPin, bPin};
 	}
 	
-	public abstract double getCurrent();
+	public abstract Current getCurrent();
 
-	public double getU() {
-		return (aPin == null ? 0 : aPin.state) - (bPin == null ? 0 : bPin.state);
+	public Voltage getU() {
+		return new Voltage((aPin == null ? 0 : aPin.state) - (bPin == null ? 0 : bPin.state));
 	}
 
-	public double getBipoleU() {
+	public Voltage getBipoleU() {
 		return getU();
 	}
 }

--- a/src/main/java/mods/eln/sim/mna/component/Capacitor.java
+++ b/src/main/java/mods/eln/sim/mna/component/Capacitor.java
@@ -2,12 +2,15 @@ package mods.eln.sim.mna.component;
 
 import mods.eln.sim.mna.SubSystem;
 import mods.eln.sim.mna.misc.ISubSystemProcessI;
+import mods.eln.sim.mna.primitives.Capacitance;
+import mods.eln.sim.mna.primitives.Conductance;
+import mods.eln.sim.mna.primitives.Current;
+import mods.eln.sim.mna.primitives.Energy;
 import mods.eln.sim.mna.state.State;
 
 public class Capacitor extends Bipole  implements ISubSystemProcessI {
 
-    private double c = 0;
-    double cdt;
+	private Capacitance c = new Capacitance();
 
 	public Capacitor() {
 	}
@@ -17,28 +20,29 @@ public class Capacitor extends Bipole  implements ISubSystemProcessI {
 	}
 
 	@Override
-	public double getCurrent() {
-		return 0;
+	public Current getCurrent() {
+		return new Current();
 	}
 
-	public void setC(double c) {
+	public void setC(final Capacitance c) {
 		this.c = c;
 		dirty();
 	}
 
 	@Override
 	public void applyTo(SubSystem s) {
-		cdt = c / s.getDt();
+	    Conductance cdt = c.divide(s.getDt());
 		
-		s.addToA(aPin, aPin, cdt);
-		s.addToA(aPin, bPin, -cdt);
-		s.addToA(bPin, bPin, cdt);
-		s.addToA(bPin, aPin, -cdt);
+		s.addToA(aPin, aPin, cdt.getValue());
+		s.addToA(aPin, bPin, -cdt.getValue());
+		s.addToA(bPin, bPin, cdt.getValue());
+		s.addToA(bPin, aPin, -cdt.getValue());
 	}
 	
 	@Override
 	public void simProcessI(SubSystem s) {
-		double add = (s.getXSafe(aPin) - s.getXSafe(bPin)) * cdt;
+		Conductance cdt = c.divide(s.getDt());
+		double add = s.getXSafe(aPin).substract(s.getXSafe(bPin)).multiply(cdt);
 		s.addToI(aPin, add);
 		s.addToI(bPin, -add);
 	}
@@ -55,12 +59,11 @@ public class Capacitor extends Bipole  implements ISubSystemProcessI {
 		s.addProcess(this);
 	}
 
-	public double getE() {
-		double u = getU();
-		return u * u * c / 2;
+	public Energy getE() {
+		return new Energy(getU(), c);
 	}
 
-	public double getC() {
+	public Capacitance getC() {
 		return c;
 	}
 }

--- a/src/main/java/mods/eln/sim/mna/component/Inductor.java
+++ b/src/main/java/mods/eln/sim/mna/component/Inductor.java
@@ -4,6 +4,9 @@ import net.minecraft.nbt.NBTTagCompound;
 import mods.eln.misc.INBTTReady;
 import mods.eln.sim.mna.SubSystem;
 import mods.eln.sim.mna.misc.ISubSystemProcessI;
+import mods.eln.sim.mna.primitives.Current;
+import mods.eln.sim.mna.primitives.Inductance;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sim.mna.state.CurrentState;
 import mods.eln.sim.mna.state.State;
 
@@ -11,8 +14,8 @@ public class Inductor extends Bipole implements ISubSystemProcessI, INBTTReady {
 
 	String name;
 
-    private double l = 0;
-    double ldt;
+    private Inductance l = new Inductance();
+    Resistance ldt;
 
     private CurrentState currentState = new CurrentState();
 
@@ -26,29 +29,29 @@ public class Inductor extends Bipole implements ISubSystemProcessI, INBTTReady {
 	}
 
 	@Override
-	public double getCurrent() {
-		return currentState.state;
+	public Current getCurrent() {
+		return new Current(currentState.state);
 	}
 
-	public void setL(double l) {
+	public void setL(Inductance l) {
 		this.l = l;
 		dirty();
 	}
 
 	@Override
 	public void applyTo(SubSystem s) {
-		ldt = -l/s.getDt();
+		ldt = l.divide(s.getDt()).opposite();
 		
 		s.addToA(aPin, currentState, 1);
 		s.addToA(bPin, currentState, -1);
 		s.addToA(currentState, aPin, 1);
 		s.addToA(currentState, bPin, -1);
-		s.addToA(currentState, currentState, ldt);
+		s.addToA(currentState, currentState, ldt.getValue());
 	}
 	
 	@Override
 	public void simProcessI(SubSystem s) {
-		s.addToI(currentState, ldt * currentState.state);
+		s.addToI(currentState, ldt.getValue() * currentState.state);
 	}
 
 	@Override

--- a/src/main/java/mods/eln/sim/mna/component/InterSystemAbstraction.java
+++ b/src/main/java/mods/eln/sim/mna/component/InterSystemAbstraction.java
@@ -3,6 +3,8 @@ package mods.eln.sim.mna.component;
 import mods.eln.sim.mna.RootSystem;
 import mods.eln.sim.mna.SubSystem;
 import mods.eln.sim.mna.misc.IDestructor;
+import mods.eln.sim.mna.primitives.Resistance;
+import mods.eln.sim.mna.primitives.Voltage;
 import mods.eln.sim.mna.state.State;
 import mods.eln.sim.mna.state.VoltageState;
 
@@ -67,11 +69,11 @@ public class InterSystemAbstraction implements IAbstractor, IDestructor {
 	}
 
 	void calibrate() {
-		double u = (aState.state + bState.state) / 2;
+		Voltage u = new Voltage((aState.state + bState.state) / 2);
 		aNewDelay.setU(u);
 		bNewDelay.setU(u);
 
-		double r = interSystemResistor.getR() / 2;
+		Resistance r = interSystemResistor.getR().multiply(0.5);
 		aNewResistor.setR(r);
 		bNewResistor.setR(r);
 	}

--- a/src/main/java/mods/eln/sim/mna/component/Line.java
+++ b/src/main/java/mods/eln/sim/mna/component/Line.java
@@ -6,6 +6,9 @@ import java.util.LinkedList;
 import mods.eln.sim.mna.RootSystem;
 import mods.eln.sim.mna.SubSystem;
 import mods.eln.sim.mna.misc.ISubSystemProcessFlush;
+import mods.eln.sim.mna.primitives.Current;
+import mods.eln.sim.mna.primitives.Resistance;
+import mods.eln.sim.mna.primitives.Voltage;
 import mods.eln.sim.mna.state.State;
 
 public class Line extends Resistor implements ISubSystemProcessFlush, IAbstractor {
@@ -30,11 +33,10 @@ public class Line extends Resistor implements ISubSystemProcessFlush, IAbstracto
 	}
 
 	public void recalculateR() {
-		double R = 0;
+		Resistance R = new Resistance();
 		for(Resistor r : resistors) {
-			R += r.getR();
+			R = R.add(r.getR());
 		}
-		
 		setR(R);
 	}
 	
@@ -113,16 +115,16 @@ public class Line extends Resistor implements ISubSystemProcessFlush, IAbstracto
 
 	@Override
 	public void simProcessFlush() {
-		double i = (aPin.state - bPin.state) * getRInv();
-		double u = aPin.state;
+		Current i = new Voltage(aPin.state - bPin.state).multiply(getRInv());
+		Voltage u = new Voltage(aPin.state);
 		Iterator<Resistor> ir = resistors.iterator();
 		Iterator<State> is = states.iterator();
 
         while (is.hasNext()) {
 			State s = is.next();
 			Resistor r = ir.next();
-			u -= r.getR() * i;
-			s.state = u;
+			u = u.substract(r.getR().multiply(i));
+			s.state = u.getValue();
 			//u -= r.getR() * i;
 		}
 	}

--- a/src/main/java/mods/eln/sim/mna/component/PowerSource.java
+++ b/src/main/java/mods/eln/sim/mna/component/PowerSource.java
@@ -3,6 +3,9 @@ package mods.eln.sim.mna.component;
 import mods.eln.misc.INBTTReady;
 import mods.eln.sim.mna.SubSystem;
 import mods.eln.sim.mna.misc.IRootSystemPreStepProcess;
+import mods.eln.sim.mna.primitives.Current;
+import mods.eln.sim.mna.primitives.Power;
+import mods.eln.sim.mna.primitives.Voltage;
 import mods.eln.sim.mna.state.State;
 import net.minecraft.nbt.NBTTagCompound;
 
@@ -10,31 +13,33 @@ public class PowerSource extends VoltageSource implements IRootSystemPreStepProc
 	
 	String name;
 
-    double P, Umax, Imax;
-	
+	Power P;
+	Voltage Umax;
+	Current Imax;
+    
 	public PowerSource(String name,State aPin) {
 		super(name, aPin, null);
 		this.name = name;
 	}
 
-	public void setP(double P) {
+	public void setP(Power P) {
 		this.P = P;
 	}
 	
-	void setMax(double Umax, double Imax) {
+	void setMax(Voltage Umax, Current Imax) {
 		this.Umax = Umax;
 		this.Imax = Imax;
 	}
 
-	public void setImax(double imax) {
+	public void setImax(Current imax) {
 		Imax = imax;
 	}
 	
-	public void setUmax(double umax) {
+	public void setUmax(Voltage umax) {
 		Umax = umax;
 	}
 
-	public double getP() {
+	public Power getP() {
 		return P;
 	}
 
@@ -55,16 +60,16 @@ public class PowerSource extends VoltageSource implements IRootSystemPreStepProc
 	public void rootSystemPreStepProcess() {
 		SubSystem.Th t = aPin.getSubSystem().getTh(aPin, this);
 		
-		double U = (Math.sqrt(t.U * t.U + 4 * P * t.R) + t.U) / 2;
-		U =  Math.min(Math.min(U, Umax), t.U + t.R * Imax);
-		if (Double.isNaN(U)) U = 0;
-		if (U < t.U) U = t.U;
+		Voltage U = new Voltage(Math.sqrt(t.U.getValue() * t.U.getValue() + 4 * P.getValue() * t.R.getValue())).add(t.U).multiply(0.5);
+		U =  Voltage.min(Voltage.min(U, Umax), t.U.add(t.R.multiply(Imax)));
+		if (U.isNaN()) U = new Voltage();
+		U = Voltage.max(U, t.U);
 	
 		setU(U);
 	}
 
-	public double getEffectiveP() {
-		return getBipoleU() * getCurrent();
+	public Power getEffectiveP() {
+		return getBipoleU().multiply(getCurrent());
 	}
 
 	@Override
@@ -73,9 +78,9 @@ public class PowerSource extends VoltageSource implements IRootSystemPreStepProc
 		
 		str += name;
 		
-		setP(nbt.getDouble(str + "P"));
-		setUmax(nbt.getDouble(str + "Umax"));
-		setImax(nbt.getDouble(str + "Imax"));
+		setP(new Power(nbt.getDouble(str + "P")));
+		setUmax(new Voltage(nbt.getDouble(str + "Umax")));
+		setImax(new Current(nbt.getDouble(str + "Imax")));
 	}
 
 	@Override
@@ -84,8 +89,8 @@ public class PowerSource extends VoltageSource implements IRootSystemPreStepProc
 		
 		str += name;
 		
-		nbt.setDouble(str + "P", getP());
-		nbt.setDouble(str + "Umax", Umax);
-		nbt.setDouble(str + "Imax", Imax);
+		nbt.setDouble(str + "P", getP().getValue());
+		nbt.setDouble(str + "Umax", Umax.getValue());
+		nbt.setDouble(str + "Imax", Imax.getValue());
 	}
 }

--- a/src/main/java/mods/eln/sim/mna/component/ResistorSwitch.java
+++ b/src/main/java/mods/eln/sim/mna/component/ResistorSwitch.java
@@ -3,6 +3,7 @@ package mods.eln.sim.mna.component;
 import net.minecraft.nbt.NBTTagCompound;
 import mods.eln.misc.INBTTReady;
 import mods.eln.sim.mna.misc.MnaConst;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sim.mna.state.State;
 
 public class ResistorSwitch extends Resistor implements INBTTReady {
@@ -12,7 +13,7 @@ public class ResistorSwitch extends Resistor implements INBTTReady {
 
     boolean state = false;
 
-    protected double baseR = 1;
+    protected Resistance baseR = new Resistance(1);
 
 	public ResistorSwitch(String name, State aPin, State bPin) {
 		super(aPin, bPin);
@@ -25,9 +26,9 @@ public class ResistorSwitch extends Resistor implements INBTTReady {
 	}
 
 	@Override
-	public Resistor setR(double r) {
+	public Resistor setR(Resistance r) {
 		baseR = r;
-		return super.setR(state ? r : (ultraImpedance ? MnaConst.ultraImpedance : MnaConst.highImpedance));
+		return super.setR(state ? r : (ultraImpedance ? Resistor.ultraImpedance : Resistor.highImpedance));
 	}
 
 	public boolean getState() {
@@ -37,8 +38,8 @@ public class ResistorSwitch extends Resistor implements INBTTReady {
 	@Override
 	public void readFromNBT(NBTTagCompound nbt, String str) {
 		str += name;
-		setR(nbt.getDouble(str + "R"));
-		if (Double.isNaN(baseR) || baseR == 0) {
+		setR(new Resistance(nbt.getDouble(str + "R")));
+		if (baseR.isNaN() || baseR.getValue() == 0) {
 			if (ultraImpedance)  ultraImpedance(); else highImpedance();
 		}
 		setState(nbt.getBoolean(str + "State"));
@@ -47,7 +48,7 @@ public class ResistorSwitch extends Resistor implements INBTTReady {
 	@Override
 	public void writeToNBT(NBTTagCompound nbt, String str) {
 		str += name;
-		nbt.setDouble(str + "R", baseR);
+		nbt.setDouble(str + "R", baseR.getValue());
 		nbt.setBoolean(str + "State", getState());
 	}
 

--- a/src/main/java/mods/eln/sim/mna/component/VoltageSource.java
+++ b/src/main/java/mods/eln/sim/mna/component/VoltageSource.java
@@ -3,6 +3,9 @@ package mods.eln.sim.mna.component;
 import mods.eln.misc.INBTTReady;
 import mods.eln.sim.mna.SubSystem;
 import mods.eln.sim.mna.misc.ISubSystemProcessI;
+import mods.eln.sim.mna.primitives.Current;
+import mods.eln.sim.mna.primitives.Power;
+import mods.eln.sim.mna.primitives.Voltage;
 import mods.eln.sim.mna.state.CurrentState;
 import mods.eln.sim.mna.state.State;
 import net.minecraft.nbt.NBTTagCompound;
@@ -12,7 +15,7 @@ public class VoltageSource extends Bipole implements ISubSystemProcessI, INBTTRe
 
 	String name;
 
-    double u = 0;
+    Voltage u = new Voltage();
     private CurrentState currentState = new CurrentState();
 
 	public VoltageSource(String name) {
@@ -24,12 +27,12 @@ public class VoltageSource extends Bipole implements ISubSystemProcessI, INBTTRe
 		this.name = name;
 	}
 
-	public VoltageSource setU(double u) {
+	public VoltageSource setU(Voltage u) {
 		this.u = u;
 		return this;
 	}
 	
-	public double getU() {
+	public Voltage getU() {
 		return u;
 	}
 	
@@ -57,16 +60,16 @@ public class VoltageSource extends Bipole implements ISubSystemProcessI, INBTTRe
 
 	@Override
 	public void simProcessI(SubSystem s) {
-		s.addToI(getCurrentState(), u);
+		s.addToI(getCurrentState(), u.getValue());
 	}
 
-	public double getI() {
-		return -getCurrentState().state;
+	public Current getI() {
+		return new Current(-getCurrentState().state);
 	}
 
 	@Override
-	public double getCurrent() {
-		return -getCurrentState().state;
+	public Current getCurrent() {
+		return new Current(-getCurrentState().state);
 	}
 
 	public CurrentState getCurrentState() {
@@ -76,18 +79,18 @@ public class VoltageSource extends Bipole implements ISubSystemProcessI, INBTTRe
 	@Override
 	public void readFromNBT(NBTTagCompound nbt, String str) {
 		str += name;
-		setU(nbt.getDouble(str + "U"));
+		setU(new Voltage(nbt.getDouble(str + "U")));
 		currentState.state = (nbt.getDouble(str + "Istate"));
 	}
 
 	@Override
 	public void writeToNBT(NBTTagCompound nbt, String str) {
 		str += name;
-		nbt.setDouble(str + "U", u);
+		nbt.setDouble(str + "U", u.getValue());
 		nbt.setDouble(str + "Istate", currentState.state);
 	}
 
-	public double getP() {
-		return getU() * getI();
+	public Power getP() {
+		return getU().multiply(getI());
 	}
 }

--- a/src/main/java/mods/eln/sim/mna/primitives/Capacitance.java
+++ b/src/main/java/mods/eln/sim/mna/primitives/Capacitance.java
@@ -1,0 +1,25 @@
+package mods.eln.sim.mna.primitives;
+
+public class Capacitance extends Unit {
+    static final String _unit = "F";
+    
+    public Capacitance() {
+    	super();
+    }
+    
+    public Capacitance(double value) {
+    	super(value);
+    }
+    
+    public Capacitance add(final Capacitance other) {
+    	return new Capacitance(_value + other._value);
+    }
+    
+    public Capacitance substract(final Capacitance other) {
+    	return new Capacitance(_value - other._value);
+    }
+    
+    public Conductance divide(final Timedelta timedelta) {
+    	return new Conductance(_value / timedelta._value);
+    }
+}

--- a/src/main/java/mods/eln/sim/mna/primitives/Conductance.java
+++ b/src/main/java/mods/eln/sim/mna/primitives/Conductance.java
@@ -1,0 +1,25 @@
+package mods.eln.sim.mna.primitives;
+
+public class Conductance extends Unit {
+    static final String _unit = "S";
+    
+    public Conductance() {
+    	super();
+    }
+    
+    public Conductance(double value) {
+    	super(value);
+    }
+    
+    public Conductance add(final Conductance other) {
+    	return new Conductance(_value + other._value);
+    }
+    
+    public Conductance substract(final Conductance other) {
+    	return new Conductance(_value - other._value);
+    }
+    
+    public Current multiply(final Voltage voltage) {
+    	return new Current(_value * voltage._value);
+    }
+}

--- a/src/main/java/mods/eln/sim/mna/primitives/Current.java
+++ b/src/main/java/mods/eln/sim/mna/primitives/Current.java
@@ -1,0 +1,37 @@
+package mods.eln.sim.mna.primitives;
+
+public class Current extends Unit {
+    static final String _unit = "A";
+    
+    public Current() {
+    	super();
+    }
+    
+    public Current(double value) {
+    	super(value);
+    }
+    
+    public Current add(final Current other) {
+    	return new Current(_value + other._value);
+    }
+    
+    public Current substract(final Current other) {
+    	return new Current(_value - other._value);
+    }
+    
+    public Voltage multiply(final Resistance resistance) {
+    	return new Voltage(_value * resistance._value);
+    }
+    
+    public Power multiply(final Voltage voltage) {
+    	return new Power(_value * voltage._value);
+    }
+
+	public Current multiply(double value) {
+		return new Current(_value * value);
+	}
+	
+	public Current opposite() {
+		return new Current(-_value);
+	}
+}

--- a/src/main/java/mods/eln/sim/mna/primitives/Energy.java
+++ b/src/main/java/mods/eln/sim/mna/primitives/Energy.java
@@ -1,0 +1,17 @@
+package mods.eln.sim.mna.primitives;
+
+public class Energy extends Unit {
+    static final String _unit = "V";
+    
+    public Energy() {
+    	super();
+    }
+    
+    public Energy(double value) {
+    	super(value);
+    }
+    
+    public Energy(final Voltage voltage, final Capacitance capacity) {  	
+    	super(voltage._value * voltage._value * capacity._value / 2);
+    }
+}

--- a/src/main/java/mods/eln/sim/mna/primitives/Inductance.java
+++ b/src/main/java/mods/eln/sim/mna/primitives/Inductance.java
@@ -1,0 +1,21 @@
+package mods.eln.sim.mna.primitives;
+
+public class Inductance extends Unit {
+    static final String _unit = "H";
+    
+    public Inductance() {
+    	super();
+    }
+    
+    public Inductance(double value) {
+    	super(value);
+    }
+    
+    public Inductance substract(final Inductance other) {
+    	return new Inductance(_value - other._value);
+    }
+
+	public Resistance divide(Timedelta dt) {
+		return new Resistance(_value / dt._value);
+	}
+}

--- a/src/main/java/mods/eln/sim/mna/primitives/Power.java
+++ b/src/main/java/mods/eln/sim/mna/primitives/Power.java
@@ -1,0 +1,29 @@
+package mods.eln.sim.mna.primitives;
+
+public class Power extends Unit {
+    static final String _unit = "W";
+    
+    public Power() {
+    	super();
+    }
+    
+    public Power(double value) {
+    	super(value);
+    }
+    
+    public Power add(final Power other) {
+    	return new Power(_value + other._value);
+    }
+    
+    public Power substract(final Power other) {
+    	return new Power(_value - other._value);
+    }
+    
+    public Voltage divide(final Current current) {
+    	return new Voltage(_value / current._value);
+    }
+    
+    public Current divide(final Voltage voltage) {
+    	return new Current(_value / voltage._value);
+    }
+}

--- a/src/main/java/mods/eln/sim/mna/primitives/Resistance.java
+++ b/src/main/java/mods/eln/sim/mna/primitives/Resistance.java
@@ -1,0 +1,49 @@
+package mods.eln.sim.mna.primitives;
+
+public class Resistance extends Unit {
+    static final String _unit = "ohm";
+    
+    public Resistance() {
+    	super();
+    }
+    
+    public Resistance(double value) {
+    	super(value);
+    }
+    
+    public Resistance substract(final Resistance other) {
+    	return new Resistance(_value - other._value);
+    }
+    
+    public Voltage multiply(final Current current) {
+    	return new Voltage(_value * current._value);
+    }
+    
+    public Resistance multiply(double value) {
+    	return new Resistance(_value * value);
+    }
+    
+    public double multiply(final Conductance conductance) {
+    	return _value * conductance._value;
+    }
+    
+    public Conductance invert() {
+    	return new Conductance(1 / _value);
+    }
+
+	public double getValue() {
+		return _value;
+	}
+
+	public Resistance add(final Resistance other) {
+		return new Resistance(_value + other._value);
+	}
+
+	public double divide(Resistance other) {
+		return _value / other._value;
+	}
+
+	public Resistance opposite() {
+		return new Resistance(-_value);
+	}
+}

--- a/src/main/java/mods/eln/sim/mna/primitives/Timedelta.java
+++ b/src/main/java/mods/eln/sim/mna/primitives/Timedelta.java
@@ -1,0 +1,13 @@
+package mods.eln.sim.mna.primitives;
+
+public class Timedelta extends Unit {
+    static final String _unit = "s";
+    
+    public Timedelta() {
+    	super();
+    }
+    
+    public Timedelta(double value) {
+    	super(value);
+    }
+}

--- a/src/main/java/mods/eln/sim/mna/primitives/Unit.java
+++ b/src/main/java/mods/eln/sim/mna/primitives/Unit.java
@@ -1,0 +1,22 @@
+package mods.eln.sim.mna.primitives;
+
+public abstract class Unit {
+	final double _value;
+    static final String _unit = "s";
+    
+    public Unit() {
+    	_value = 0;
+    }
+    
+    public Unit(double value) {
+    	_value = value;
+    }
+    
+    public boolean isNaN() {
+    	return Double.isNaN(_value);
+    }
+    
+	public double getValue() {
+		return _value;
+	}
+}

--- a/src/main/java/mods/eln/sim/mna/primitives/Voltage.java
+++ b/src/main/java/mods/eln/sim/mna/primitives/Voltage.java
@@ -1,0 +1,50 @@
+package mods.eln.sim.mna.primitives;
+
+public class Voltage extends Unit {
+    static final String _unit = "V";
+    
+    public Voltage() {
+    	super();
+    }
+    
+    public Voltage(double value) {
+    	super(value);
+    }
+    
+    public Voltage add(final Voltage other) {
+    	return new Voltage(_value + other._value);
+    }
+    
+    public Voltage substract(final Voltage other) {
+    	return new Voltage(_value - other._value);
+    }
+    
+    public Power multiply(final Current current) {
+    	return new Power(_value * current._value);
+    }
+    
+    public Current multiply(final Conductance conductance) {
+    	return new Current(_value * conductance._value);
+    }
+    
+    public Voltage multiply(final double value)
+    {
+    	return new Voltage(_value * value);
+    }
+
+	public Current divide(Resistance resistance) {
+		return new Current(_value / resistance._value);
+	}
+	
+	public Resistance divide(Current current) {
+		return new Resistance(_value / current._value);
+	}
+	
+	public static Voltage min(final Voltage first, final Voltage second) {
+		return new Voltage(Math.min(first._value, second._value));
+	}
+	
+	public static Voltage max(final Voltage first, final Voltage second) {
+		return new Voltage(Math.max(first._value, second._value));
+	}
+}

--- a/src/main/java/mods/eln/sim/mna/state/State.java
+++ b/src/main/java/mods/eln/sim/mna/state/State.java
@@ -6,6 +6,7 @@ import mods.eln.sim.mna.RootSystem;
 import mods.eln.sim.mna.SubSystem;
 import mods.eln.sim.mna.component.Component;
 import mods.eln.sim.mna.component.IAbstractor;
+import mods.eln.sim.mna.primitives.Voltage;
 
 public class State {
 

--- a/src/main/java/mods/eln/sim/mna/state/VoltageState.java
+++ b/src/main/java/mods/eln/sim/mna/state/VoltageState.java
@@ -1,5 +1,7 @@
 package mods.eln.sim.mna.state;
 
+import mods.eln.sim.mna.primitives.Voltage;
+
 public class VoltageState extends State {
 
 	public double getU() {

--- a/src/main/java/mods/eln/sim/nbt/NbtElectricalGateOutputProcess.java
+++ b/src/main/java/mods/eln/sim/nbt/NbtElectricalGateOutputProcess.java
@@ -5,6 +5,8 @@ import mods.eln.misc.INBTTReady;
 import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.mna.SubSystem;
 import mods.eln.sim.mna.component.Capacitor;
+import mods.eln.sim.mna.primitives.Capacitance;
+import mods.eln.sim.mna.primitives.Voltage;
 import net.minecraft.nbt.NBTTagCompound;
 
 public class NbtElectricalGateOutputProcess extends Capacitor implements INBTTReady {
@@ -24,9 +26,9 @@ public class NbtElectricalGateOutputProcess extends Capacitor implements INBTTRe
 		this.highImpedance = enable;
 		double baseC = Eln.instance.gateOutputCurrent / Eln.instance.electricalFrequancy / Eln.SVU;
 		if (enable) {
-			setC(baseC / 1000);
+			setC(new Capacitance(baseC / 1000));
 		} else {
-			setC(baseC);
+			setC(new Capacitance(baseC));
 		}
 	}
 	
@@ -83,7 +85,7 @@ public class NbtElectricalGateOutputProcess extends Capacitor implements INBTTRe
 		this.U = U;
 	}
 	
-	public double getU() {
-		return U;
+	public Voltage getU() {
+		return new Voltage(U);
 	}
 }

--- a/src/main/java/mods/eln/sim/nbt/NbtResistor.java
+++ b/src/main/java/mods/eln/sim/nbt/NbtResistor.java
@@ -3,6 +3,7 @@ package mods.eln.sim.nbt;
 import net.minecraft.nbt.NBTTagCompound;
 import mods.eln.misc.INBTTReady;
 import mods.eln.sim.mna.component.Resistor;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sim.mna.state.State;
 
 public class NbtResistor extends Resistor implements INBTTReady {
@@ -17,12 +18,12 @@ public class NbtResistor extends Resistor implements INBTTReady {
 	@Override
 	public void readFromNBT(NBTTagCompound nbt, String str) {
 		name += str;
-		setR(nbt.getDouble(str + "R"));
+		setR(new Resistance(nbt.getDouble(str + "R")));
 	}
 
 	@Override
 	public void writeToNBT(NBTTagCompound nbt, String str) {
 		name += str;
-		nbt.setDouble(str + "R", getR());
+		nbt.setDouble(str + "R", getR().getValue());
 	}
 }

--- a/src/main/java/mods/eln/sim/process/destruct/BipoleVoltageWatchdog.java
+++ b/src/main/java/mods/eln/sim/process/destruct/BipoleVoltageWatchdog.java
@@ -21,6 +21,6 @@ public class BipoleVoltageWatchdog extends ValueWatchdog {
 
 	@Override
 	double getValue() {
-		return bipole.getU();
+		return bipole.getU().getValue();
 	}
 }

--- a/src/main/java/mods/eln/sim/process/destruct/ResistorPowerWatchdog.java
+++ b/src/main/java/mods/eln/sim/process/destruct/ResistorPowerWatchdog.java
@@ -21,6 +21,6 @@ public class ResistorPowerWatchdog extends ValueWatchdog {
 	
 	@Override
 	double getValue() {
-		return resistor.getP();
+		return resistor.getP().getValue();
 	}
 }

--- a/src/main/java/mods/eln/sim/process/heater/ResistorHeatThermalLoad.java
+++ b/src/main/java/mods/eln/sim/process/heater/ResistorHeatThermalLoad.java
@@ -16,6 +16,6 @@ public class ResistorHeatThermalLoad implements IProcess {
 
 	@Override
 	public void process(double time) {
-		load.movePowerTo(r.getP());
+		load.movePowerTo(r.getP().getValue());
 	}
 }

--- a/src/main/java/mods/eln/simplenode/energyconverter/EnergyConverterElnToOtherNode.java
+++ b/src/main/java/mods/eln/simplenode/energyconverter/EnergyConverterElnToOtherNode.java
@@ -13,6 +13,7 @@ import mods.eln.node.simple.SimpleNode;
 import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.IProcess;
 import mods.eln.sim.ThermalLoad;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sim.nbt.NbtElectricalLoad;
 import mods.eln.sim.nbt.NbtResistor;
 import mods.eln.sim.process.destruct.VoltageStateWatchDog;
@@ -83,7 +84,7 @@ public class EnergyConverterElnToOtherNode extends SimpleNode {
 
         @Override
 		public void process(double time) {
-			energyBuffer += powerInResistor.getP() * time;
+			energyBuffer += powerInResistor.getP().getValue() * time;
 			timeout -= time;
 			if (timeout < 0) {
 				timeout = 0.05;
@@ -94,7 +95,7 @@ public class EnergyConverterElnToOtherNode extends SimpleNode {
 					double factor = Math.min(1, energyMiss / energyBufferMax * 2);
 					if (factor < 0.005) factor = 0;
 					double inP = factor * inPowerMax * inPowerFactor;
-					powerInResistor.setR(inStdVoltage * inStdVoltage / inP);
+					powerInResistor.setR(new Resistance(inStdVoltage * inStdVoltage / inP));
 				}
 			}
 		}

--- a/src/main/java/mods/eln/simplenode/test/TestNode.java
+++ b/src/main/java/mods/eln/simplenode/test/TestNode.java
@@ -6,6 +6,7 @@ import mods.eln.node.simple.SimpleNode;
 import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.mna.component.Resistor;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sim.nbt.NbtElectricalLoad;
 
 public class TestNode extends SimpleNode {
@@ -43,7 +44,7 @@ public class TestNode extends SimpleNode {
 		electricalComponentList.add(resistor);
 
 		load.setRs(10);
-		resistor.setR(90);
+		resistor.setR(new Resistance(90));
 
 		connect();
 	}

--- a/src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerDescriptor.java
@@ -8,6 +8,7 @@ import mods.eln.misc.Obj3D.Obj3DPart;
 import mods.eln.misc.UtilsClient;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.sim.mna.component.Resistor;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sim.nbt.NbtElectricalLoad;
 import mods.eln.sixnode.electricalcable.ElectricalCableDescriptor;
 import mods.eln.wiki.Data;
@@ -109,7 +110,7 @@ public class BatteryChargerDescriptor extends SixNodeDescriptor {
 		if (!powerOn)
 			powerload.highImpedance();
 		else
-			powerload.setR(Rp);
+			powerload.setR(new Resistance(Rp));
 	}
 
 	@Override

--- a/src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerElement.java
+++ b/src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerElement.java
@@ -17,6 +17,7 @@ import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.IProcess;
 import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.mna.component.Resistor;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sim.nbt.NbtElectricalLoad;
 import mods.eln.sim.process.destruct.ResistorPowerWatchdog;
 import mods.eln.sim.process.destruct.VoltageStateWatchDog;
@@ -203,7 +204,7 @@ public class BatteryChargerElement extends SixNodeElement {
 					eff = Math.pow(0.9, booster.stackSize);
 				}
 				
-				energyCounter += powerResistor.getP() * time * eff;
+				energyCounter += powerResistor.getP().getValue() * time * eff;
 				
 				for (int idx = 0; idx < 4; idx++) {
 					ItemStack stack = inventory.getStackInSlot(idx);
@@ -219,7 +220,7 @@ public class BatteryChargerElement extends SixNodeElement {
 				if (energyCounter < descriptor.nominalPower * time * 2 * boost) {
 					//double target = descriptor.nominalPower * time * 2;
 					double power = Math.min(descriptor.nominalPower * boost, (descriptor.nominalPower * time * 2 * boost - energyCounter) / time);
-					powerResistor.setR(Math.max(powerLoad.getU() * powerLoad.getU() / power, descriptor.Rp / boost));
+					powerResistor.setR(new Resistance(Math.max(powerLoad.getU() * powerLoad.getU() / power, descriptor.Rp / boost)));
 				} else {
 					descriptor.setRp(powerResistor, false);
 				}

--- a/src/main/java/mods/eln/sixnode/diode/DiodeDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/diode/DiodeDescriptor.java
@@ -10,6 +10,7 @@ import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.ThermalLoadInitializer;
 import mods.eln.sim.mna.component.ResistorSwitch;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sixnode.electricalcable.ElectricalCableDescriptor;
 import mods.eln.wiki.Data;
 import net.minecraft.entity.player.EntityPlayer;
@@ -92,7 +93,7 @@ public class DiodeDescriptor extends SixNodeDescriptor {
 	}
 	
 	public void applyTo(ResistorSwitch resistorSwitch) {
-		resistorSwitch.setR(stdU/stdI);
+		resistorSwitch.setR(new Resistance(stdU/stdI));
 	}
 	
 	@Override

--- a/src/main/java/mods/eln/sixnode/electricalcable/ElectricalCableDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricalcable/ElectricalCableDescriptor.java
@@ -10,6 +10,7 @@ import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.mna.component.Resistor;
 import mods.eln.sim.mna.misc.MnaConst;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.wiki.Data;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
@@ -110,7 +111,7 @@ public class ElectricalCableDescriptor extends SixNodeDescriptor {
 	}
 
 	public void applyTo(Resistor resistor, double factor) {
-		resistor.setR(electricalRs * factor);
+		resistor.setR(new Resistance(electricalRs * factor));
 	}
 	
 	public void applyTo(ThermalLoad thermalLoad) {

--- a/src/main/java/mods/eln/sixnode/electricalgatesource/ElectricalGateSourceElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalgatesource/ElectricalGateSourceElement.java
@@ -118,7 +118,7 @@ public class ElectricalGateSourceElement extends SixNodeElement {
 		super.networkSerialize(stream);
 		try {
 			stream.writeByte((front.toInt() << 4));
-			stream.writeFloat((float) outputGateProcess.getU());
+			stream.writeFloat((float) outputGateProcess.getU().getValue());
 		} catch (IOException e) {
 			e.printStackTrace();
 		}

--- a/src/main/java/mods/eln/sixnode/electricalsource/ElectricalSourceElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalsource/ElectricalSourceElement.java
@@ -13,6 +13,7 @@ import mods.eln.node.six.SixNodeElement;
 import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.mna.component.VoltageSource;
+import mods.eln.sim.mna.primitives.Voltage;
 import mods.eln.sim.nbt.NbtElectricalLoad;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
@@ -46,7 +47,7 @@ public class ElectricalSourceElement extends SixNodeElement {
 		color = b & 0xF;
 		colorCare = (b >> 4) & 1;
 		
-		voltageSource.setU(nbt.getDouble("voltage"));
+		voltageSource.setU(new Voltage(nbt.getDouble("voltage")));
 	}
 	
 	public static boolean canBePlacedOnSide(Direction side, int type) {
@@ -58,7 +59,7 @@ public class ElectricalSourceElement extends SixNodeElement {
  		super.writeToNBT(nbt);
 		nbt.setByte("color", (byte)(color + (colorCare << 4)));
 		
-		nbt.setDouble("voltage", voltageSource.getU());
+		nbt.setDouble("voltage", voltageSource.getU().getValue());
 	}
 
 	@Override
@@ -78,7 +79,7 @@ public class ElectricalSourceElement extends SixNodeElement {
 
 	@Override
 	public String multiMeterString() {
-		return Utils.plotUIP(electricalLoad.getU(), voltageSource.getI());
+		return Utils.plotUIP(electricalLoad.getU(), voltageSource.getI().getValue());
 	}
 	
 	@Override
@@ -91,7 +92,7 @@ public class ElectricalSourceElement extends SixNodeElement {
 		super.networkSerialize(stream);
 		try {
 			stream.writeByte((color << 4));
-	    	stream.writeFloat((float) voltageSource.getU());
+			stream.writeFloat((float) voltageSource.getU().getValue());
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
@@ -135,7 +136,7 @@ public class ElectricalSourceElement extends SixNodeElement {
 		try {
 			switch(stream.readByte()) {
                 case setVoltageId:
-                    voltageSource.setU(stream.readFloat());
+                    voltageSource.setU(new Voltage(stream.readFloat()));
                     needPublish();
                     break;
 			}

--- a/src/main/java/mods/eln/sixnode/electricalswitch/ElectricalSwitchDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricalswitch/ElectricalSwitchDescriptor.java
@@ -10,11 +10,13 @@ import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.ThermalLoadInitializer;
 import mods.eln.sim.mna.component.Resistor;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.wiki.Data;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
+
 import org.lwjgl.opengl.GL11;
 
 import java.util.List;
@@ -104,7 +106,7 @@ public class ElectricalSwitchDescriptor extends SixNodeDescriptor {
 	
 	public void applyTo(Resistor resistor, boolean state) {
 		if (state) {
-			resistor.setR(electricalRs);
+			resistor.setR(new Resistance(electricalRs));
 		} else {
 			resistor.highImpedance();
 		}

--- a/src/main/java/mods/eln/sixnode/electricalswitch/ElectricalSwitchElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalswitch/ElectricalSwitchElement.java
@@ -12,6 +12,7 @@ import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.mna.component.Resistor;
 import mods.eln.sim.mna.component.ResistorSwitch;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sim.nbt.NbtElectricalLoad;
 import mods.eln.sim.process.destruct.VoltageStateWatchDog;
 import mods.eln.sim.process.destruct.WorldExplosion;
@@ -138,7 +139,7 @@ public class ElectricalSwitchElement extends SixNodeElement {
     	descriptor.applyTo(aLoad);
     	descriptor.applyTo(bLoad);
     	
-    	switchResistor.setR(descriptor.electricalRs);
+    	switchResistor.setR(new Resistance(descriptor.electricalRs));
     	
     	setSwitchState(switchState);
 	}

--- a/src/main/java/mods/eln/sixnode/electricasensor/ElectricalSensorProcess.java
+++ b/src/main/java/mods/eln/sixnode/electricasensor/ElectricalSensorProcess.java
@@ -19,13 +19,13 @@ public class ElectricalSensorProcess implements IProcess {
 			double output = 0;
 			switch (sensor.dirType) {
                 case ElectricalSensorElement.dirNone:
-                    output = Math.abs(sensor.resistor.getCurrent());
+                    output = Math.abs(sensor.resistor.getCurrent().getValue());
                     break;
                 case ElectricalSensorElement.dirAB:
-                    output = (sensor.resistor.getCurrent());
+                    output = (sensor.resistor.getCurrent().getValue());
                     break;
                 case ElectricalSensorElement.dirBA:
-                    output = (-sensor.resistor.getCurrent());
+                    output = (-sensor.resistor.getCurrent().getValue());
                     break;
 			}
 			
@@ -34,13 +34,13 @@ public class ElectricalSensorProcess implements IProcess {
             double output = 0;
             switch (sensor.dirType) {
                 case ElectricalSensorElement.dirNone:
-                    output = Math.abs(sensor.resistor.getCurrent() * sensor.aLoad.getU());
+                    output = Math.abs(sensor.resistor.getCurrent().getValue() * sensor.aLoad.getU());
                     break;
                 case ElectricalSensorElement.dirAB:
-                    output = (sensor.resistor.getCurrent() * sensor.aLoad.getU());
+                    output = (sensor.resistor.getCurrent().getValue() * sensor.aLoad.getU());
                     break;
                 case ElectricalSensorElement.dirBA:
-                    output = (-sensor.resistor.getCurrent() * sensor.aLoad.getU());
+                    output = (-sensor.resistor.getCurrent().getValue() * sensor.aLoad.getU());
                     break;
             }
 

--- a/src/main/java/mods/eln/sixnode/groundcable/GroundCableElement.java
+++ b/src/main/java/mods/eln/sixnode/groundcable/GroundCableElement.java
@@ -17,6 +17,7 @@ import mods.eln.node.six.SixNodeElementInventory;
 import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.mna.component.VoltageSource;
+import mods.eln.sim.mna.primitives.Voltage;
 import mods.eln.sim.nbt.NbtElectricalLoad;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
@@ -41,7 +42,7 @@ public class GroundCableElement extends SixNodeElement {
 	
 		electricalLoadList.add(electricalLoad);
 		electricalComponentList.add(ground);
-		ground.setU(0);
+		ground.setU(new Voltage());
 	}
 
 	@Override

--- a/src/main/java/mods/eln/sixnode/hub/HubElement.java
+++ b/src/main/java/mods/eln/sixnode/hub/HubElement.java
@@ -13,6 +13,7 @@ import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.mna.component.Component;
 import mods.eln.sim.mna.component.Resistor;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sim.nbt.NbtElectricalLoad;
 import mods.eln.sim.process.destruct.VoltageStateWatchDog;
 import mods.eln.sim.process.destruct.WorldExplosion;
@@ -159,7 +160,7 @@ public class HubElement extends SixNodeElement {
 				
 				if (inventory.getStackInSlot(HubContainer.cableSlotId + lrdu[0].toInt()) != null && inventory.getStackInSlot(HubContainer.cableSlotId + lrdu[1].toInt()) != null) {
 					Resistor r = new Resistor(electricalLoad[lrdu[0].toInt()], electricalLoad[lrdu[1].toInt()]);
-					r.setR(getCableDescriptorFromLrdu(lrdu[0]).electricalRs + getCableDescriptorFromLrdu(lrdu[1]).electricalRs);
+					r.setR(new Resistance(getCableDescriptorFromLrdu(lrdu[0]).electricalRs + getCableDescriptorFromLrdu(lrdu[1]).electricalRs));
 					electricalComponentList.add(r);
 					
 					//ResistorCurrentWatchdog watchdog = new ResistorCurrentWatchdog();

--- a/src/main/java/mods/eln/sixnode/lampsocket/LampSocketElement.java
+++ b/src/main/java/mods/eln/sixnode/lampsocket/LampSocketElement.java
@@ -14,6 +14,7 @@ import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.MonsterPopFreeProcess;
 import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.mna.component.Resistor;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sim.nbt.NbtElectricalLoad;
 import mods.eln.sixnode.electricalcable.ElectricalCableDescriptor;
 import net.minecraft.entity.player.EntityPlayer;
@@ -197,7 +198,7 @@ public class LampSocketElement extends SixNodeElement {
 
 	@Override
 	public String multiMeterString() {
-		return Utils.plotVolt("U:", positiveLoad.getU()) + Utils.plotAmpere("I:", lampResistor.getCurrent());
+		return Utils.plotVolt("U:", positiveLoad.getU()) + Utils.plotAmpere("I:", lampResistor.getCurrent().getValue());
 	}
 
 	@Override
@@ -244,7 +245,7 @@ public class LampSocketElement extends SixNodeElement {
 		lampDescriptor = (LampDescriptor) Utils.getItemObject(lamp);
 
 		if (lampDescriptor == null) {
-			lampResistor.setR(Double.POSITIVE_INFINITY);
+			lampResistor.setR(new Resistance(Double.POSITIVE_INFINITY));
 		} else {
 			lampDescriptor.applyTo(lampResistor);
 		}

--- a/src/main/java/mods/eln/sixnode/lampsocket/LampSocketProcess.java
+++ b/src/main/java/mods/eln/sixnode/lampsocket/LampSocketProcess.java
@@ -203,12 +203,12 @@ public class LampSocketProcess implements IProcess, INBTTReady /*,LightBlockObse
 			double lightDouble = 0;
 			switch (lampDescriptor.type) {
                 case Incandescent:
-                    lightDouble = lampDescriptor.nominalLight * (Math.abs(lamp.lampResistor.getU()) - lampDescriptor.minimalU) / (lampDescriptor.nominalU - lampDescriptor.minimalU);
+                    lightDouble = lampDescriptor.nominalLight * (Math.abs(lamp.lampResistor.getU().getValue()) - lampDescriptor.minimalU) / (lampDescriptor.nominalU - lampDescriptor.minimalU);
                     lightDouble = (lightDouble * 16);
 
                     break;
                 case eco:
-                    double U = Math.abs(lamp.lampResistor.getU());
+                    double U = Math.abs(lamp.lampResistor.getU().getValue());
                     if (U < lampDescriptor.minimalU) {
                         stableProb = 0;
                         lightDouble = 0;
@@ -246,7 +246,7 @@ public class LampSocketProcess implements IProcess, INBTTReady /*,LightBlockObse
 			/*
 			 * double overFactor = (lamp.electricalLoad.Uc-lampDescriptor.minimalU) /(lampDescriptor.nominalU-lampDescriptor.minimalU);
 			 */
-			double overFactor = (lamp.lampResistor.getP()) / (lampDescriptor.nominalP);
+			double overFactor = (lamp.lampResistor.getP().getValue()) / (lampDescriptor.nominalP);
 			if (overFactor < 0)
 				overFactor = 0;
 

--- a/src/main/java/mods/eln/sixnode/lampsupply/LampSupplyElement.java
+++ b/src/main/java/mods/eln/sixnode/lampsupply/LampSupplyElement.java
@@ -12,6 +12,7 @@ import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.IProcess;
 import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.mna.component.Resistor;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sim.nbt.NbtElectricalLoad;
 import mods.eln.sim.process.destruct.VoltageStateWatchDog;
 import mods.eln.sim.process.destruct.WorldExplosion;
@@ -81,7 +82,7 @@ public class LampSupplyElement extends SixNodeElement {
 
 		@Override
 		public void process(double time) {
-			loadResistor.setR(1 / RpStack);
+			loadResistor.setR(new Resistance(1 / RpStack));
 			RpStack = 0;
 		}
 	}

--- a/src/main/java/mods/eln/sixnode/powercapacitorsix/PowerCapacitorSixElement.java
+++ b/src/main/java/mods/eln/sixnode/powercapacitorsix/PowerCapacitorSixElement.java
@@ -14,6 +14,8 @@ import mods.eln.sim.IProcess;
 import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.mna.component.Capacitor;
 import mods.eln.sim.mna.component.Resistor;
+import mods.eln.sim.mna.primitives.Capacitance;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sim.nbt.NbtElectricalLoad;
 import mods.eln.sim.process.destruct.BipoleVoltageWatchdog;
 import mods.eln.sim.process.destruct.WorldExplosion;
@@ -62,10 +64,10 @@ public class PowerCapacitorSixElement extends SixNodeElement {
 		public void process(double time) {
 			if (eLeft <= 0) {
 				eLeft = 0;
-				dischargeResistor.setR(stdDischargeResistor);
+				dischargeResistor.setR(new Resistance(stdDischargeResistor));
 			} else {
-				eLeft -= dischargeResistor.getP() * time;
-				dischargeResistor.setR(eLegaliseResistor);
+				eLeft -= dischargeResistor.getP().getValue() * time;
+				dischargeResistor.setR(new Resistance(eLegaliseResistor));
 			}
 		}
 	}
@@ -91,7 +93,7 @@ public class PowerCapacitorSixElement extends SixNodeElement {
 
 	@Override
 	public String multiMeterString() {
-		return Utils.plotVolt("U", Math.abs(capacitor.getU())) + Utils.plotAmpere("I", capacitor.getCurrent());
+		return Utils.plotVolt("U", Math.abs(capacitor.getU().getValue())) + Utils.plotAmpere("I", capacitor.getCurrent().getValue());
 	}
 
 	@Override
@@ -114,23 +116,23 @@ public class PowerCapacitorSixElement extends SixNodeElement {
 	}
 
 	public void setupPhysical() {
-		double eOld = capacitor.getE();
-		capacitor.setC(descriptor.getCValue(inventory));
-		stdDischargeResistor = descriptor.dischargeTao / capacitor.getC();
+		double eOld = capacitor.getE().getValue();
+		capacitor.setC(new Capacitance(descriptor.getCValue(inventory)));
+		stdDischargeResistor = descriptor.dischargeTao / capacitor.getC().getValue();
 		
 		watchdog.setUNominal(descriptor.getUNominalValue(inventory));
 		punkProcess.eLegaliseResistor = Math.pow(descriptor.getUNominalValue(inventory), 2) / 400;
 		
 		if (fromNbt) {
-			dischargeResistor.setR(stdDischargeResistor);
+			dischargeResistor.setR(new Resistance(stdDischargeResistor));
 			fromNbt = false;
 		} else {
-			double deltaE = capacitor.getE() - eOld;
+			double deltaE = capacitor.getE().getValue() - eOld;
 			punkProcess.eLeft += deltaE;
 			if (deltaE < 0) {
-				dischargeResistor.setR(stdDischargeResistor);
+				dischargeResistor.setR(new Resistance(stdDischargeResistor));
 			} else {
-				dischargeResistor.setR(punkProcess.eLegaliseResistor);
+				dischargeResistor.setR(new Resistance(punkProcess.eLegaliseResistor));
 			}
 		}
 	}

--- a/src/main/java/mods/eln/sixnode/powerinductorsix/PowerInductorSixElement.java
+++ b/src/main/java/mods/eln/sixnode/powerinductorsix/PowerInductorSixElement.java
@@ -11,6 +11,7 @@ import mods.eln.node.six.SixNodeElementInventory;
 import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.mna.component.Inductor;
+import mods.eln.sim.mna.primitives.Inductance;
 import mods.eln.sim.nbt.NbtElectricalLoad;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
@@ -60,7 +61,7 @@ public class PowerInductorSixElement extends SixNodeElement {
 
 	@Override
 	public String multiMeterString() {
-		return Utils.plotVolt("U", Math.abs(inductor.getU())) + Utils.plotAmpere("I", inductor.getCurrent());
+		return Utils.plotVolt("U", Math.abs(inductor.getU().getValue())) + Utils.plotAmpere("I", inductor.getCurrent().getValue());
 	}
 
 	@Override
@@ -81,7 +82,7 @@ public class PowerInductorSixElement extends SixNodeElement {
     
 	public void setupPhysical() {
 		double rs = descriptor.getRsValue(inventory);
-		inductor.setL(descriptor.getlValue(inventory));
+		inductor.setL(new Inductance(descriptor.getlValue(inventory)));
 		positiveLoad.setRs(rs);
 		negativeLoad.setRs(rs);
 

--- a/src/main/java/mods/eln/transparentnode/autominer/AutoMinerSlowProcess.java
+++ b/src/main/java/mods/eln/transparentnode/autominer/AutoMinerSlowProcess.java
@@ -11,6 +11,7 @@ import mods.eln.misc.INBTTReady;
 import mods.eln.misc.Utils;
 import mods.eln.ore.OreBlock;
 import mods.eln.sim.IProcess;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sixnode.lampsocket.LightBlockEntity;
 import mods.eln.sound.SoundCommand;
 import mods.eln.sound.SoundLooper;
@@ -98,7 +99,7 @@ public class AutoMinerSlowProcess implements IProcess, INBTTReady {
 			}
 		}
 
-		energyCounter += miner.powerResistor.getP() * time;
+		energyCounter += miner.powerResistor.getP().getValue() * time;
 
 		if (job != jobType.none && job != jobType.full && job != jobType.chestFull && job != jobType.done) {
 			if (energyCounter >= energyTarget || (job == jobType.ore && !isReadyToDrill()) || !miner.powerOk) {
@@ -173,14 +174,14 @@ public class AutoMinerSlowProcess implements IProcess, INBTTReady {
                 } else {
                     // double p = drill.nominalPower + (scanner != null ? scanner.OperationEnergy/drill.operationTime : 0);
                     double p = drill.nominalPower;
-                    miner.powerResistor.setR(Math.pow(miner.descriptor.nominalVoltage, 2.0) / p);
+                    miner.powerResistor.setR(new Resistance(Math.pow(miner.descriptor.nominalVoltage, 2.0) / p));
                 }
                 break;
             case pipeAdd:
-                miner.powerResistor.setR(miner.descriptor.pipeOperationRp);
+                miner.powerResistor.setR(new Resistance(miner.descriptor.pipeOperationRp));
                 break;
             case pipeRemove:
-                miner.powerResistor.setR(miner.descriptor.pipeOperationRp);
+                miner.powerResistor.setR(new Resistance(miner.descriptor.pipeOperationRp));
                 break;
 		}
 

--- a/src/main/java/mods/eln/transparentnode/battery/BatteryDescriptor.java
+++ b/src/main/java/mods/eln/transparentnode/battery/BatteryDescriptor.java
@@ -14,6 +14,7 @@ import mods.eln.sim.BatterySlowProcess;
 import mods.eln.sim.Simulator;
 import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.mna.component.Resistor;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sixnode.electricalcable.ElectricalCableDescriptor;
 import mods.eln.wiki.Data;
 import net.minecraft.entity.item.EntityItem;
@@ -149,7 +150,7 @@ public class BatteryDescriptor extends TransparentNodeDescriptor  {
 	}
 	
 	public void applyTo(Resistor resistor) {
-		resistor.setR(electricalRp);
+		resistor.setR(new Resistance(electricalRp));
 	}
 	
 	public void applyTo(BatteryProcess battery) {

--- a/src/main/java/mods/eln/transparentnode/battery/BatteryElement.java
+++ b/src/main/java/mods/eln/transparentnode/battery/BatteryElement.java
@@ -13,6 +13,7 @@ import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.mna.component.Resistor;
 import mods.eln.sim.mna.component.ResistorSwitch;
 import mods.eln.sim.mna.component.VoltageSource;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sim.nbt.NbtBatteryProcess;
 import mods.eln.sim.nbt.NbtBatterySlowProcess;
 import mods.eln.sim.nbt.NbtElectricalLoad;
@@ -171,7 +172,7 @@ public class BatteryElement extends TransparentNodeElement {
 		descriptor.applyTo(thermalLoad);
 		descriptor.applyTo(dischargeResistor);
 		descriptor.applyTo(batterySlowProcess);
-		cutSwitch.setR(descriptor.electricalRs/2);
+		cutSwitch.setR(new Resistance(descriptor.electricalRs/2));
 		cutLoad.setRs(descriptor.electricalRs/2);
 		negativeLoad.setRs(descriptor.electricalRs);
 		if (fromItemStack) {

--- a/src/main/java/mods/eln/transparentnode/battery/BatteryInventoryProcess.java
+++ b/src/main/java/mods/eln/transparentnode/battery/BatteryInventoryProcess.java
@@ -1,6 +1,7 @@
 package mods.eln.transparentnode.battery;
 
 import mods.eln.sim.IProcess;
+import mods.eln.sim.mna.primitives.Resistance;
 
 public class BatteryInventoryProcess implements IProcess {
 
@@ -49,9 +50,9 @@ public class BatteryInventoryProcess implements IProcess {
 		
 		double currentDropPower = (U - battery.descriptor.currentDropVoltage) / battery.descriptor.electricalU * battery.descriptor.currentDropFactor;
 		if (currentDropPower > 0.1) {
-			battery.dischargeResistor.setR(1 / (1 / battery.descriptor.electricalRp + 1 / ((U * U) / currentDropPower)));
+			battery.dischargeResistor.setR(new Resistance(1 / (1 / battery.descriptor.electricalRp + 1 / ((U * U) / currentDropPower))));
 		} else {
-			battery.dischargeResistor.setR(battery.descriptor.electricalRp);
+			battery.dischargeResistor.setR(new Resistance(battery.descriptor.electricalRp));
 		}
 	}
 }

--- a/src/main/java/mods/eln/transparentnode/eggincubator/EggIncubatorDescriptor.java
+++ b/src/main/java/mods/eln/transparentnode/eggincubator/EggIncubatorDescriptor.java
@@ -9,6 +9,7 @@ import mods.eln.node.transparent.TransparentNodeDescriptor;
 import mods.eln.node.transparent.TransparentNodeEntity;
 import mods.eln.sim.mna.component.Resistor;
 import mods.eln.sim.mna.misc.MnaConst;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sim.nbt.NbtElectricalLoad;
 import mods.eln.sixnode.electricalcable.ElectricalCableDescriptor;
 import mods.eln.wiki.Data;
@@ -109,9 +110,9 @@ public class EggIncubatorDescriptor extends TransparentNodeDescriptor {
 	
 	public void setState(Resistor powerLoad, boolean enable) {
 		if (enable)
-			powerLoad.setR(Rp);
+			powerLoad.setR(new Resistance(Rp));
 		else
-			powerLoad.setR(MnaConst.highImpedance);
+			powerLoad.setR(Resistor.highImpedance);
 	}
 
 	@Override

--- a/src/main/java/mods/eln/transparentnode/eggincubator/EggIncubatorElement.java
+++ b/src/main/java/mods/eln/transparentnode/eggincubator/EggIncubatorElement.java
@@ -64,7 +64,7 @@ public class EggIncubatorElement extends TransparentNodeElement {
 		
 		@Override
 		public void process(double time) {
-			energy -= powerResistor.getP() * time;
+			energy -= powerResistor.getP().getValue() * time;
 			if (inventory.getStackInSlot(EggIncubatorContainer.EggSlotId) != null) {
 				descriptor.setState(powerResistor, true);
 				if (energy <= 0) {

--- a/src/main/java/mods/eln/transparentnode/electricalantennarx/ElectricalAntennaRxElement.java
+++ b/src/main/java/mods/eln/transparentnode/electricalantennarx/ElectricalAntennaRxElement.java
@@ -13,6 +13,9 @@ import mods.eln.node.transparent.TransparentNodeElement;
 import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.mna.component.PowerSource;
+import mods.eln.sim.mna.primitives.Current;
+import mods.eln.sim.mna.primitives.Power;
+import mods.eln.sim.mna.primitives.Voltage;
 import mods.eln.sim.nbt.NbtElectricalGateInput;
 import mods.eln.sim.nbt.NbtElectricalLoad;
 import net.minecraft.entity.player.EntityPlayer;
@@ -36,11 +39,11 @@ public class ElectricalAntennaRxElement extends TransparentNodeElement {
 	}
 	
 	public void setPowerOut(double power) {
-		powerSrc.setP(power);
+		powerSrc.setP(new Power(power));
 	}
 	
 	public void rxDisconnect() {
-		powerSrc.setP(0.0);
+		powerSrc.setP(new Power(0.0));
 	}
 
 	public ElectricalAntennaRxElement(TransparentNode transparentNode, TransparentNodeDescriptor descriptor) {
@@ -91,8 +94,8 @@ public class ElectricalAntennaRxElement extends TransparentNodeElement {
 	@Override
 	public void initialize() {
 		descriptor.cable.applyTo(powerOut);
-		powerSrc.setUmax(descriptor.electricalMaximalVoltage * 2);
-		powerSrc.setImax(descriptor.electricalMaximalVoltage * descriptor.electricalMaximalPower * 2);
+		powerSrc.setUmax(new Voltage(descriptor.electricalMaximalVoltage * 2));
+		powerSrc.setImax(new Current(descriptor.electricalMaximalVoltage * descriptor.electricalMaximalPower * 2));
 		connect();
 	}
 

--- a/src/main/java/mods/eln/transparentnode/electricalantennarx/ElectricalAntennaRxSlowProcess.java
+++ b/src/main/java/mods/eln/transparentnode/electricalantennarx/ElectricalAntennaRxSlowProcess.java
@@ -12,7 +12,7 @@ public class ElectricalAntennaRxSlowProcess implements IProcess {
 	
 	@Override
 	public void process(double time) {
-		if (element.powerSrc.getP() > element.descriptor.electricalMaximalPower) {
+		if (element.powerSrc.getP().getValue() > element.descriptor.electricalMaximalPower) {
 			element.node.physicalSelfDestruction(2.0f);
 		} else if (element.powerOut.getU() > element.descriptor.electricalMaximalVoltage) {
 			element.node.physicalSelfDestruction(2.0f);

--- a/src/main/java/mods/eln/transparentnode/electricalantennatx/ElectricalAntennaTxElectricalProcess.java
+++ b/src/main/java/mods/eln/transparentnode/electricalantennatx/ElectricalAntennaTxElectricalProcess.java
@@ -18,7 +18,7 @@ public class ElectricalAntennaTxElectricalProcess implements IProcess {
 		if (rx == null) {
 			element.signalOutProcess.setOutputNormalized(1.0);
 		} else {
-			double powerOut = Math.max(0, element.powerResistor.getP() * element.powerEfficency - 2);
+			double powerOut = Math.max(0, element.powerResistor.getP().getValue() * element.powerEfficency - 2);
 			rx.setPowerOut(powerOut);
 			element.signalOutProcess.setU(rx.getSignal());
 		}

--- a/src/main/java/mods/eln/transparentnode/electricalantennatx/ElectricalAntennaTxElement.java
+++ b/src/main/java/mods/eln/transparentnode/electricalantennatx/ElectricalAntennaTxElement.java
@@ -13,7 +13,9 @@ import mods.eln.node.transparent.TransparentNodeDescriptor;
 import mods.eln.node.transparent.TransparentNodeElement;
 import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.ThermalLoad;
+import mods.eln.sim.mna.component.Resistor;
 import mods.eln.sim.mna.misc.MnaConst;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sim.nbt.NbtElectricalGateInput;
 import mods.eln.sim.nbt.NbtElectricalGateOutput;
 import mods.eln.sim.nbt.NbtElectricalGateOutputProcess;
@@ -121,9 +123,9 @@ public class ElectricalAntennaTxElement extends TransparentNodeElement{
 	void calculatePowerInRp() {
 		double cmd = commandIn.getNormalized();
 		if (cmd == 0.0)
-			powerResistor.setR(MnaConst.highImpedance);
+			powerResistor.setR(Resistor.highImpedance);
 		else
-			powerResistor.setR(descriptor.electricalNominalInputR / cmd);
+			powerResistor.setR(new Resistance(descriptor.electricalNominalInputR / cmd));
 	}
 	
 	@Override

--- a/src/main/java/mods/eln/transparentnode/electricalantennatx/ElectricalAntennaTxSlowProcess.java
+++ b/src/main/java/mods/eln/transparentnode/electricalantennatx/ElectricalAntennaTxSlowProcess.java
@@ -76,7 +76,7 @@ public class ElectricalAntennaTxSlowProcess implements IProcess {
 				element.txDisconnect();
 				Coordonate coordCpy = new Coordonate(coord);
 				coordCpy.move(element.front.getInverse());
-				if (element.powerResistor.getP() > 50) {
+				if (element.powerResistor.getP().getValue() > 50) {
 					if (coordCpy.world().blockExists(coordCpy.x, coordCpy.y, coordCpy.z)) {
 						if (coordCpy.getBlock() == Blocks.air) {
 							coordCpy.world().setBlock(coordCpy.x, coordCpy.y, coordCpy.z, Blocks.fire);
@@ -96,11 +96,11 @@ public class ElectricalAntennaTxSlowProcess implements IProcess {
 			
 			for (Object o : list) {
 				Entity e = (Entity) o;
-				e.setFire((int) (Math.pow(element.powerResistor.getP() / 100.0, 2) + 0.5));
+				e.setFire((int) (Math.pow(element.powerResistor.getP().getValue() / 100.0, 2) + 0.5));
 			}			
 		}
 		
-		if (element.powerResistor.getP() > element.descriptor.electricalMaximalPower) {
+		if (element.powerResistor.getP().getValue() > element.descriptor.electricalMaximalPower) {
 			element.node.physicalSelfDestruction(2.0f);
 		}
 		if (element.powerIn.getU() > element.descriptor.electricalMaximalVoltage) {

--- a/src/main/java/mods/eln/transparentnode/electricalfurnace/ElectricalFurnaceElement.java
+++ b/src/main/java/mods/eln/transparentnode/electricalfurnace/ElectricalFurnaceElement.java
@@ -190,7 +190,7 @@ public class ElectricalFurnaceElement extends TransparentNodeElement {
 	public void networkSerialize(java.io.DataOutputStream stream) {
 		super.networkSerialize(stream);
 		try {
-			stream.writeByte((powerOn ? 1 : 0) + (heatingCorpResistor.getP() > 5 ? 2 : 0));
+			stream.writeByte((powerOn ? 1 : 0) + (heatingCorpResistor.getP().getValue() > 5 ? 2 : 0));
 			
 			stream.writeShort((int) thermalRegulator.getTarget());
 			stream.writeShort((int) thermalLoad.Tc);
@@ -204,7 +204,7 @@ public class ElectricalFurnaceElement extends TransparentNodeElement {
 				stream.writeShort(stack.getItemDamage());				
 			}
 			
-			stream.writeShort((int) heatingCorpResistor.getP());
+			stream.writeShort((int) heatingCorpResistor.getP().getValue());
 			stream.writeFloat((float) electricalLoad.getU());
 			stream.writeFloat((float) slowRefreshProcess.processState());
 			stream.writeFloat((float) slowRefreshProcess.processStatePerSecond());

--- a/src/main/java/mods/eln/transparentnode/electricalmachine/ElectricalMachineDescriptor.java
+++ b/src/main/java/mods/eln/transparentnode/electricalmachine/ElectricalMachineDescriptor.java
@@ -14,6 +14,7 @@ import mods.eln.sim.ElectricalStackMachineProcess;
 import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.ThermalLoadInitializer;
 import mods.eln.sim.mna.component.Resistor;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sixnode.electricalcable.ElectricalCableDescriptor;
 import mods.eln.sound.SoundCommand;
 import mods.eln.wiki.Data;
@@ -101,7 +102,7 @@ public class ElectricalMachineDescriptor extends TransparentNodeDescriptor imple
 	}
 
 	public void applyTo(Resistor resistor) {
-		resistor.setR(resistorR);
+		resistor.setR(new Resistance(resistorR));
 	}
 
 	public void applyTo(ElectricalStackMachineProcess machine) {

--- a/src/main/java/mods/eln/transparentnode/electricalmachine/ElectricalMachineElement.java
+++ b/src/main/java/mods/eln/transparentnode/electricalmachine/ElectricalMachineElement.java
@@ -155,8 +155,8 @@ public class ElectricalMachineElement extends TransparentNodeElement implements 
 
 	public void networkSerialize(java.io.DataOutputStream stream) {
 		super.networkSerialize(stream);
-		double fPower = electricalResistor.getP() / descriptor.nominalP;
-		if (electricalResistor.getP() < 11) fPower = 0.0;
+		double fPower = electricalResistor.getP().getValue() / descriptor.nominalP;
+		if (electricalResistor.getP().getValue() < 11) fPower = 0.0;
 		if (fPower > 1.9) fPower = 1.9;
 		try {
 			stream.writeByte((int)(fPower * 64));

--- a/src/main/java/mods/eln/transparentnode/electricalmachine/ElectricalMachineSlowProcess.java
+++ b/src/main/java/mods/eln/transparentnode/electricalmachine/ElectricalMachineSlowProcess.java
@@ -20,7 +20,7 @@ public class ElectricalMachineSlowProcess implements IProcess {
 			
 			@Override
 			public SoundCommand mustStart() {
-				double P = element.electricalResistor.getP();
+				double P = element.electricalResistor.getP().getValue();
 				double normalisedP = Math.pow(P / element.descriptor.nominalP, 0.5);
 				if (element.descriptor.runingSound == null || normalisedP < 0.3) return null;
 				
@@ -33,7 +33,7 @@ public class ElectricalMachineSlowProcess implements IProcess {
 
 	@Override
 	public void process(double time) {
-		double P = element.electricalResistor.getP();
+		double P = element.electricalResistor.getP().getValue();
 		lastUpdate += time;
 		if (!boot) {
 			if (Math.abs((P - lastPublishAt) / (lastPublishAt + 1.0)) > 1 / 32.0 && lastUpdate > 0.2) {

--- a/src/main/java/mods/eln/transparentnode/powercapacitor/PowerCapacitorElement.java
+++ b/src/main/java/mods/eln/transparentnode/powercapacitor/PowerCapacitorElement.java
@@ -20,6 +20,8 @@ import mods.eln.sim.mna.component.Capacitor;
 import mods.eln.sim.mna.component.Inductor;
 import mods.eln.sim.mna.component.Resistor;
 import mods.eln.sim.mna.component.VoltageSource;
+import mods.eln.sim.mna.primitives.Capacitance;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sim.mna.process.PowerSourceBipole;
 import mods.eln.sim.nbt.NbtElectricalLoad;
 import mods.eln.sim.process.destruct.BipoleVoltageWatchdog;
@@ -66,10 +68,10 @@ public class PowerCapacitorElement extends TransparentNodeElement {
 		public void process(double time) {
 			if(eLeft <= 0){
 				eLeft = 0;
-				dischargeResistor.setR(stdDischargeResistor);
+				dischargeResistor.setR(new Resistance(stdDischargeResistor));
 			}else{
-				eLeft -= dischargeResistor.getP()*time;
-				dischargeResistor.setR(eLegaliseResistor);
+				eLeft -= dischargeResistor.getP().getValue()*time;
+				dischargeResistor.setR(new Resistance(eLegaliseResistor));
 			}
 		}
 	}
@@ -97,7 +99,7 @@ public class PowerCapacitorElement extends TransparentNodeElement {
 
 	@Override
 	public String multiMeterString(Direction side) {
-		return Utils.plotAmpere("I", capacitor.getCurrent());
+		return Utils.plotAmpere("I", capacitor.getCurrent().getValue());
 	}
 
 	@Override
@@ -126,23 +128,23 @@ public class PowerCapacitorElement extends TransparentNodeElement {
 	
 	boolean fromNbt = false;
 	public void setupPhysical() {
-		double eOld = capacitor.getE();
-		capacitor.setC(descriptor.getCValue(inventory));
-		stdDischargeResistor = descriptor.dischargeTao/capacitor.getC();
+		double eOld = capacitor.getE().getValue();
+		capacitor.setC(new Capacitance(descriptor.getCValue(inventory)));
+		stdDischargeResistor = descriptor.dischargeTao/capacitor.getC().getValue();
 		
 		watchdog.setUNominal(descriptor.getUNominalValue(inventory));
 		punkProcess.eLegaliseResistor = Math.pow(descriptor.getUNominalValue(inventory),2)/400;
 		
 		if(fromNbt){
-			dischargeResistor.setR(stdDischargeResistor);
+			dischargeResistor.setR(new Resistance(stdDischargeResistor));
 			fromNbt = false;
 		}else{
-			double deltaE = capacitor.getE()-eOld;
+			double deltaE = capacitor.getE().getValue()-eOld;
 			punkProcess.eLeft += deltaE;
 			if(deltaE < 0){
-				dischargeResistor.setR(stdDischargeResistor);
+				dischargeResistor.setR(new Resistance(stdDischargeResistor));
 			}else{
-				dischargeResistor.setR(punkProcess.eLegaliseResistor);
+				dischargeResistor.setR(new Resistance(punkProcess.eLegaliseResistor));
 			}
 		}	
 	}

--- a/src/main/java/mods/eln/transparentnode/powerinductor/PowerInductorElement.java
+++ b/src/main/java/mods/eln/transparentnode/powerinductor/PowerInductorElement.java
@@ -16,6 +16,7 @@ import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.mna.component.Inductor;
 import mods.eln.sim.mna.component.VoltageSource;
+import mods.eln.sim.mna.primitives.Inductance;
 import mods.eln.sim.mna.process.PowerSourceBipole;
 import mods.eln.sim.nbt.NbtElectricalLoad;
 import net.minecraft.entity.player.EntityPlayer;
@@ -65,7 +66,7 @@ public class PowerInductorElement extends TransparentNodeElement {
 
 	@Override
 	public String multiMeterString(Direction side) {
-		return Utils.plotAmpere("I", inductor.getCurrent());
+		return Utils.plotAmpere("I", inductor.getCurrent().getValue());
 	}
 
 	@Override
@@ -94,7 +95,7 @@ public class PowerInductorElement extends TransparentNodeElement {
 	boolean fromNbt = false;
 	public void setupPhysical() {
 		double rs = descriptor.getRsValue(inventory);
-		inductor.setL(descriptor.getlValue(inventory));
+		inductor.setL(new Inductance(descriptor.getlValue(inventory)));
 		positiveLoad.setRs(rs);
 		negativeLoad.setRs(rs);
 		

--- a/src/main/java/mods/eln/transparentnode/solarpannel/SolarPannelElement.java
+++ b/src/main/java/mods/eln/transparentnode/solarpannel/SolarPannelElement.java
@@ -16,6 +16,8 @@ import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.mna.component.Resistor;
 import mods.eln.sim.mna.component.VoltageSource;
+import mods.eln.sim.mna.primitives.Current;
+import mods.eln.sim.mna.primitives.Voltage;
 import mods.eln.sim.mna.process.PowerSourceBipole;
 import mods.eln.sim.nbt.NbtElectricalLoad;
 import net.minecraft.entity.player.EntityPlayer;
@@ -125,8 +127,8 @@ public class SolarPannelElement extends TransparentNodeElement{
 	}
 	@Override
 	public void initialize() {
-		powerSource.setUmax(this.descriptor.electricalUmax);
-		powerSource.setImax(this.descriptor.electricalPmax/this.descriptor.electricalUmax * 1.5);
+		powerSource.setUmax(new Voltage(this.descriptor.electricalUmax));
+		powerSource.setImax(new Current(this.descriptor.electricalPmax/this.descriptor.electricalUmax * 1.5));
 		
 		descriptor.applyTo(positiveLoad);
 		descriptor.applyTo(negativeLoad);

--- a/src/main/java/mods/eln/transparentnode/solarpannel/SolarPannelSlowProcess.java
+++ b/src/main/java/mods/eln/transparentnode/solarpannel/SolarPannelSlowProcess.java
@@ -3,6 +3,7 @@ package mods.eln.transparentnode.solarpannel;
 import mods.eln.misc.Coordonate;
 import mods.eln.misc.Utils;
 import mods.eln.sim.IProcess;
+import mods.eln.sim.mna.primitives.Power;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
@@ -26,7 +27,7 @@ public class SolarPannelSlowProcess implements IProcess {
 			}
 			else*/
 			{
-				solarPannel.powerSource.setP(solarPannel.descriptor.electricalPmax*getSolarLight());
+				solarPannel.powerSource.setP(new Power(solarPannel.descriptor.electricalPmax*getSolarLight()));
 			}
 			timeCounter += Math.random()*timeCounterRefreshMax/2 + timeCounterRefreshMax/2;
 		}

--- a/src/main/java/mods/eln/transparentnode/teleporter/TeleporterElement.java
+++ b/src/main/java/mods/eln/transparentnode/teleporter/TeleporterElement.java
@@ -18,6 +18,7 @@ import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.IProcess;
 import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.mna.component.Resistor;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sim.nbt.NbtElectricalLoad;
 import mods.eln.sim.process.destruct.VoltageStateWatchDog;
 import mods.eln.sim.process.destruct.WorldExplosion;
@@ -239,7 +240,7 @@ public class TeleporterElement extends TransparentNodeElement implements ITelepo
 				descriptor.ghostDoorOpen.newRotate(front).plot(node.coordonate, node.coordonate, descriptor.getGhostGroupUuid());
 				break;
 			case StateCharge:
-				powerResistor.setR(Math.pow(descriptor.cable.electricalNominalVoltage, 2) / powerCharge);
+				powerResistor.setR(new Resistance(Math.pow(descriptor.cable.electricalNominalVoltage, 2) / powerCharge));
 				publisher.reconfigure(0.4, 0);
 				break;
 			case StateReserved:
@@ -460,7 +461,7 @@ public class TeleporterElement extends TransparentNodeElement implements ITelepo
 					//
 					// energyTarget *= 1.0 + Math.pow(distance / 250.0, 0.5);
 
-					energyHit += powerResistor.getP() * time;
+					energyHit += powerResistor.getP().getValue() * time;
 					processRatio = (float) (energyHit / energyTarget);
 
 					if (energyHit >= energyTarget) {

--- a/src/main/java/mods/eln/transparentnode/thermaldissipatoractive/ThermalDissipatorActiveDescriptor.java
+++ b/src/main/java/mods/eln/transparentnode/thermaldissipatoractive/ThermalDissipatorActiveDescriptor.java
@@ -10,6 +10,7 @@ import mods.eln.node.transparent.TransparentNodeDescriptor;
 import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.mna.component.Resistor;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sixnode.electricalcable.ElectricalCableDescriptor;
 import mods.eln.wiki.Data;
 import net.minecraft.entity.player.EntityPlayer;
@@ -74,7 +75,7 @@ public class ThermalDissipatorActiveDescriptor extends TransparentNodeDescriptor
 	public void applyTo(ElectricalLoad load,Resistor r)
 	{
 		cableDescriptor.applyTo(load);
-		r.setR(electricalRp);
+		r.setR(new Resistance(electricalRp));
 	}
 	
 	

--- a/src/main/java/mods/eln/transparentnode/thermaldissipatoractive/ThermalDissipatorActiveElement.java
+++ b/src/main/java/mods/eln/transparentnode/thermaldissipatoractive/ThermalDissipatorActiveElement.java
@@ -109,7 +109,7 @@ public class ThermalDissipatorActiveElement extends TransparentNodeElement{
 		
 		super.networkSerialize(stream);
 		try {
-			stream.writeFloat(lastPowerFactor = (float) (powerResistor.getP()/descriptor.electricalNominalP));
+			stream.writeFloat(lastPowerFactor = (float) (powerResistor.getP().getValue()/descriptor.electricalNominalP));
 		} catch (IOException e) {
 			
 			e.printStackTrace();

--- a/src/main/java/mods/eln/transparentnode/thermaldissipatoractive/ThermalDissipatorActiveSlowProcess.java
+++ b/src/main/java/mods/eln/transparentnode/thermaldissipatoractive/ThermalDissipatorActiveSlowProcess.java
@@ -12,7 +12,7 @@ public class ThermalDissipatorActiveSlowProcess implements IProcess{
 	@Override
 	public void process(double time) {
 		ThermalDissipatorActiveDescriptor descriptor = dissipator.descriptor;
-		double poweredFactor = dissipator.powerResistor.getP() / descriptor.electricalNominalP;
+		double poweredFactor = dissipator.powerResistor.getP().getValue() / descriptor.electricalNominalP;
 		double thermalRp = 1/(1/descriptor.thermalRp + poweredFactor/(descriptor.electricalToThermalRp));
 		dissipator.thermalLoad.setRp(thermalRp);
 		

--- a/src/main/java/mods/eln/transparentnode/turbine/TurbineElectricalProcess.java
+++ b/src/main/java/mods/eln/transparentnode/turbine/TurbineElectricalProcess.java
@@ -5,6 +5,7 @@ import mods.eln.sim.PhysicalConstant;
 import mods.eln.sim.mna.SubSystem.Th;
 import mods.eln.sim.mna.component.PowerSource;
 import mods.eln.sim.mna.misc.IRootSystemPreStepProcess;
+import mods.eln.sim.mna.primitives.Voltage;
 import mods.eln.sound.SoundCommand;
 import mods.eln.sound.SoundLooper;
 
@@ -46,27 +47,27 @@ public class TurbineElectricalProcess implements IProcess,IRootSystemPreStepProc
 		
 		Th th = turbine.positiveLoad.getSubSystem().getTh(turbine.positiveLoad, turbine.electricalPowerSourceProcess);
 		double Ut;
-		if(targetU < th.U){
-			Ut = th.U;
+		if(targetU < th.U.getValue()){
+			Ut = th.U.getValue();
 		}else if(th.isHighImpedance()){
 			Ut = targetU;
 		}else{
 			//double f = descriptor.powerOutPerDeltaU;
 			//Ut = (Math.sqrt(-4*f*th.R*th.U+f*f*th.R*th.R+4*f*targetU*th.R)+2*th.U-f*th.R)/2;	
-			double a = 1/th.R;
-			double b = descriptor.powerOutPerDeltaU - th.U/th.R;
+			double a = 1/th.R.getValue();
+			double b = descriptor.powerOutPerDeltaU - th.U.getValue()/th.R.getValue();
 			double c = -descriptor.powerOutPerDeltaU*targetU;
 			Ut = (-b + Math.sqrt(b*b-4*a*c))/(2*a);
 		}
 
-		double i = (Ut - th.U)/th.R;
+		double i = (Ut - th.U.getValue())/th.R.getValue();
 		double p = i*Ut;
 		double pMax = descriptor.nominalP*1.5;
 		if(p > pMax){
-			Ut = (Math.sqrt(th.U*th.U+4*pMax*th.R)+th.U)/2;
+			Ut = (Math.sqrt(th.U.getValue()*th.U.getValue()+4*pMax*th.R.getValue())+th.U.getValue())/2;
 			Ut =  Math.min(Ut, targetU);
 			if(Double.isNaN(Ut)) Ut = 0;
-			if(Ut < th.U) Ut = th.U;
+			if(Ut < th.U.getValue()) Ut = th.U.getValue();
 			//double pCalc = Ut*(Ut-th.U)/th.R;
 		
 		}
@@ -74,7 +75,7 @@ public class TurbineElectricalProcess implements IProcess,IRootSystemPreStepProc
 //		Ut = th.U;
 		//double Ut2 = -(Math.sqrt(-4*f*th.R*th.U+f*f*th.R*th.R+4*f*targetU*th.R)-2*th.U+f*th.R)/2;
 		
-		turbine.electricalPowerSourceProcess.setU(Ut);
+		turbine.electricalPowerSourceProcess.setU(new Voltage(Ut));
 		//turbine.electricalPowerSourceProcess.setU(th.U);
 		
 		/*PowerSource eps = turbine.electricalPowerSourceProcess;

--- a/src/main/java/mods/eln/transparentnode/turbine/TurbineElement.java
+++ b/src/main/java/mods/eln/transparentnode/turbine/TurbineElement.java
@@ -17,6 +17,7 @@ import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.mna.component.PowerSource;
 import mods.eln.sim.mna.component.Resistor;
 import mods.eln.sim.mna.component.VoltageSource;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sim.nbt.NbtElectricalLoad;
 import mods.eln.sim.nbt.NbtThermalLoad;
 import mods.eln.sim.process.destruct.ThermalLoadWatchDog;
@@ -154,7 +155,7 @@ public class TurbineElement extends TransparentNodeElement{
 	public void initialize() {
 
 		descriptor.applyTo(inputLoad);
-		inputToTurbinResistor.setR(descriptor.electricalRs*30);
+		inputToTurbinResistor.setR(new Resistance(descriptor.electricalRs*30));
 		
 		descriptor.applyTo(warmLoad);
 		descriptor.applyTo(coolLoad);

--- a/src/main/java/mods/eln/transparentnode/turbine/TurbineThermalProcess.java
+++ b/src/main/java/mods/eln/transparentnode/turbine/TurbineThermalProcess.java
@@ -29,7 +29,7 @@ public class TurbineThermalProcess implements IProcess{
 		double eff  = Math.abs(1 - (turbine.coolLoad.Tc + PhysicalConstant.Tref)/(turbine.warmLoad.Tc + PhysicalConstant.Tref));
 		if(eff < 0.05) eff = 0.05;
 
-		double E = src.getP()*time / Eln.instance.heatTurbinePowerFactor;
+		double E = src.getP().getValue()*time / Eln.instance.heatTurbinePowerFactor;
 
 		double Pout = E/time;
 		double Pin = descriptor.PoutToPin.getValue(Pout) / eff;

--- a/src/main/java/mods/eln/transparentnode/turret/TurretSlowProcess.java
+++ b/src/main/java/mods/eln/transparentnode/turret/TurretSlowProcess.java
@@ -10,6 +10,7 @@ import mods.eln.generic.GenericItemUsingDamageDescriptor;
 import mods.eln.item.EntitySensorFilterDescriptor;
 import mods.eln.misc.Coordonate;
 import mods.eln.misc.Utils;
+import mods.eln.sim.mna.primitives.Resistance;
 import mods.eln.sim.process.destruct.WorldExplosion;
 import mods.eln.sound.SoundCommand;
 import net.minecraft.block.Block;
@@ -317,7 +318,7 @@ public class TurretSlowProcess extends StateMachine {
 	
 	@Override
 	public void process(double time) {
-		element.energyBuffer += element.powerResistor.getP() * time;
+		element.energyBuffer += element.powerResistor.getP().getValue() * time;
 		
 		if(element.coordonate().getBlockExist())
 			super.process(time);
@@ -325,6 +326,6 @@ public class TurretSlowProcess extends StateMachine {
         if (actualPower == 0 )
             element.powerResistor.highImpedance();
         else
-            element.powerResistor.setR(element.load.getU() * element.load.getU() / actualPower);
+            element.powerResistor.setR(new Resistance(element.load.getU() * element.load.getU() / actualPower));
 	}	
 }

--- a/src/main/java/mods/eln/transparentnode/waterturbine/WaterTurbineElement.java
+++ b/src/main/java/mods/eln/transparentnode/waterturbine/WaterTurbineElement.java
@@ -15,6 +15,8 @@ import mods.eln.node.transparent.TransparentNodeElementInventory;
 import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.mna.component.PowerSource;
+import mods.eln.sim.mna.primitives.Current;
+import mods.eln.sim.mna.primitives.Voltage;
 import mods.eln.sim.nbt.NbtElectricalLoad;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
@@ -88,8 +90,8 @@ public class WaterTurbineElement extends TransparentNodeElement{
 		setPhysicalValue();
 		waterCoord = descriptor.getWaterCoordonate(node.coordonate.world());
 		waterCoord.applyTransformation(front, node.coordonate);
-		powerSource.setUmax(descriptor.maxVoltage);
-		powerSource.setImax(descriptor.nominalPower*5/descriptor.maxVoltage);
+		powerSource.setUmax(new Voltage(descriptor.maxVoltage));
+		powerSource.setImax(new Current(descriptor.nominalPower*5/descriptor.maxVoltage));
 		connect();
 	}
 
@@ -126,7 +128,7 @@ public class WaterTurbineElement extends TransparentNodeElement{
 		
 		super.networkSerialize(stream);
 		try {
-			stream.writeFloat((float) (powerSource.getP()/descriptor.nominalPower));
+			stream.writeFloat((float) (powerSource.getP().getValue()/descriptor.nominalPower));
 		} catch (IOException e) {
 			
 			e.printStackTrace();

--- a/src/main/java/mods/eln/transparentnode/waterturbine/WaterTurbineSlowProcess.java
+++ b/src/main/java/mods/eln/transparentnode/waterturbine/WaterTurbineSlowProcess.java
@@ -4,6 +4,7 @@ import mods.eln.misc.INBTTReady;
 import mods.eln.misc.RcRcInterpolator;
 import mods.eln.misc.Utils;
 import mods.eln.sim.IProcess;
+import mods.eln.sim.mna.primitives.Power;
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.nbt.NBTTagCompound;
@@ -38,7 +39,7 @@ public class WaterTurbineSlowProcess implements IProcess,INBTTReady {
 				filter.step((float) time);
 			}
 		
-			turbine.powerSource.setP(filter.get());
+			turbine.powerSource.setP(new Power(filter.get()));
 		}
 	}
 

--- a/src/main/java/mods/eln/transparentnode/windturbine/WindTurbineElement.java
+++ b/src/main/java/mods/eln/transparentnode/windturbine/WindTurbineElement.java
@@ -15,6 +15,7 @@ import mods.eln.node.transparent.TransparentNodeElementInventory;
 import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.mna.component.PowerSource;
+import mods.eln.sim.mna.primitives.Current;
 import mods.eln.sim.nbt.NbtElectricalLoad;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
@@ -90,7 +91,7 @@ public class WindTurbineElement extends TransparentNodeElement{
 	@Override
 	public void initialize() {
 		setPhysicalValue();
-		powerSource.setImax(descriptor.nominalPower*5/descriptor.maxVoltage);
+		powerSource.setImax(new Current(descriptor.nominalPower*5/descriptor.maxVoltage));
 		connect();
 	}
 
@@ -137,7 +138,7 @@ public class WindTurbineElement extends TransparentNodeElement{
 		super.networkSerialize(stream);
 		try {
 			stream.writeFloat((float) slowProcess.getWind());
-			stream.writeFloat((float) (powerSource.getP()/descriptor.nominalPower));
+			stream.writeFloat((float) (powerSource.getP().getValue()/descriptor.nominalPower));
 		} catch (IOException e) {
 			
 			e.printStackTrace();

--- a/src/main/java/mods/eln/transparentnode/windturbine/WindTurbineSlowProcess.java
+++ b/src/main/java/mods/eln/transparentnode/windturbine/WindTurbineSlowProcess.java
@@ -4,6 +4,8 @@ import mods.eln.misc.Coordonate;
 import mods.eln.misc.INBTTReady;
 import mods.eln.misc.Utils;
 import mods.eln.sim.IProcess;
+import mods.eln.sim.mna.primitives.Power;
+import mods.eln.sim.mna.primitives.Voltage;
 import net.minecraft.init.Blocks;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
@@ -142,8 +144,8 @@ public class WindTurbineSlowProcess implements IProcess,INBTTReady {
 		
 		
 		
-		turbine.powerSource.setP(P);	
-		turbine.powerSource.setUmax(d.maxVoltage);
+		turbine.powerSource.setP(new Power(P));
+		turbine.powerSource.setUmax(new Voltage(d.maxVoltage));
 		
 		
 		


### PR DESCRIPTION
Using Primitives is bad.
Using Primitives in physics calculation where you operate on units is very bad.

This changes should be introduced step by step. I started by mods.eln.sim.mna package. 

This should prevent calculation bugs and help finding existing ones(calculation of bad values is impossible, for example now adding resistance to current).

This will help understand equations and make code more readable.
This will help with later refactorization of code.

At this stage other packages use .getValue() method which is ugly but you cant change everything at once.

Tested on my test world with most elements, and H bridge.
