### PR TITLE
Makes electrical armor unenchantable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ eclipse
 run
 logs
 config
+saves
+*.json
+options.txt
 
 # IntelliJ
 .idea

--- a/src/main/java/mods/eln/item/electricalitem/ElectricalArmor.java
+++ b/src/main/java/mods/eln/item/electricalitem/ElectricalArmor.java
@@ -129,4 +129,9 @@ public class ElectricalArmor extends genericArmorItem implements IItemEnergyBatt
 	@Override
 	public void electricalItemUpdate(ItemStack stack,double time) {
 	}
+	
+	@Override
+	public int getItemEnchantability() {
+		return 0;
+	}
 }


### PR DESCRIPTION
Electrical armor looses actual durability if enchanted, this sets the enchantability of all electrical armor's from ELN to 0. Thus, it is now impossible to enchant them.
Closes #254 
