### PR TITLE
Make chips Ore Dictionary compatible

### DIFF
--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -4450,6 +4450,7 @@ public class Eln {
 					name, new String[] {});
 			sharedItem.addElement(subId + (id << 6), desc);
 			Data.addResource(desc.newItemStack());
+			OreDictionary.registerOre("circuitBasic", desc.newItemStack());
 		}
 		{
 			subId = 1;
@@ -4458,6 +4459,7 @@ public class Eln {
 					name, new String[] {});
 			sharedItem.addElement(subId + (id << 6), desc);
 			Data.addResource(desc.newItemStack());
+			OreDictionary.registerOre("circuitAdvanced", desc.newItemStack());
 		}
 		{
 			subId = 2;
@@ -5140,7 +5142,7 @@ public class Eln {
 				"PRP",
 				" c ",
 				Character.valueOf('c'), findItemStack("Copper Cable"),
-				Character.valueOf('R'), findItemStack("Advanced Chip"),
+				Character.valueOf('R'), "circuitAdvanced",
 				Character.valueOf('P'), findItemStack("Iron Plate"));
 
 	}
@@ -5150,7 +5152,7 @@ public class Eln {
 				"MCM",
 				"BOB",
 				" P ",
-				Character.valueOf('C'), findItemStack("Advanced Chip"),
+				Character.valueOf('C'), "circuitAdvanced",
 				Character.valueOf('O'), findItemStack("Ore Scanner"),
 				Character.valueOf('B'), findItemStack("Advanced Machine Block"),
 				Character.valueOf('M'), findItemStack("Advanced Electrical Motor"),
@@ -5602,7 +5604,7 @@ public class Eln {
 				" T ",
 				" P ",
 				Character.valueOf('T'), findItemStack("Mining Pipe"),
-				Character.valueOf('C'), findItemStack("Advanced Chip"),
+				Character.valueOf('C'), "circuitAdvanced",
 				Character.valueOf('M'), findItemStack("Advanced Electrical Motor"),
 				Character.valueOf('P'), new ItemStack(Items.diamond_pickaxe));
 
@@ -5711,7 +5713,7 @@ public class Eln {
 					"PGP",
 					"PCP",
 					"PBP",
-					Character.valueOf('C'), findItemStack("Advanced Chip"),
+					Character.valueOf('C'), "circuitAdvanced",
 					Character.valueOf('B'), findItemStack("Portable Battery"),
 					Character.valueOf('P'), new ItemStack(Items.iron_ingot),
 					Character.valueOf('G'), findItemStack("Ore Scanner"));
@@ -5725,27 +5727,27 @@ public class Eln {
 				"PPP",
 				"PCP",
 				Character.valueOf('P'), "plateCoal",
-				Character.valueOf('C'), findItemStack("Advanced Chip"));
+				Character.valueOf('C'), "circuitAdvanced");
 		addRecipe(findItemStack("E-Coal Boots"),
 				" C ",
 				"P P",
 				"P P",
 				Character.valueOf('P'), "plateCoal",
-				Character.valueOf('C'), findItemStack("Advanced Chip"));
+				Character.valueOf('C'), "circuitAdvanced");
 
 		addRecipe(findItemStack("E-Coal Chestplate"),
 				"P P",
 				"PCP",
 				"PPP",
 				Character.valueOf('P'), "plateCoal",
-				Character.valueOf('C'), findItemStack("Advanced Chip"));
+				Character.valueOf('C'), "circuitAdvanced");
 
 		addRecipe(findItemStack("E-Coal Leggings"),
 				"PPP",
 				"PCP",
 				"P P",
 				Character.valueOf('P'), "plateCoal",
-				Character.valueOf('C'), findItemStack("Advanced Chip"));
+				Character.valueOf('C'), "circuitAdvanced");
 
 	}
 
@@ -5777,7 +5779,7 @@ public class Eln {
 				"LRL",
 				"RCR",
 				"LRL",
-				Character.valueOf('C'), findItemStack("Cheap Chip"),
+				Character.valueOf('C'), "circuitBasic",
 				Character.valueOf('L'), "ingotSilicon",
 				Character.valueOf('R'), new ItemStack(Items.redstone));
 
@@ -5822,7 +5824,7 @@ public class Eln {
 				"c",
 				"m",
 				Character.valueOf('m'), findItemStack("Electrical Motor"),
-				Character.valueOf('c'), findItemStack("Advanced Chip"));
+				Character.valueOf('c'), "circuitAdvanced");
 
 		addRecipe(findItemStack("Wrench"),
 				" c ",
@@ -6022,7 +6024,7 @@ public class Eln {
 				" R ",
 				Character.valueOf('M'), findItemStack("Advanced Machine Block"),
 				Character.valueOf('C'), findItemStack("High Voltage Cable"),
-				Character.valueOf('R'), findItemStack("Advanced Chip"));
+				Character.valueOf('R'), "circuitAdvanced");
 	}
 
 
@@ -6033,7 +6035,7 @@ public class Eln {
 				"CMC",
 				" c ",
 				Character.valueOf('M'), findItemStack("Advanced Machine Block"),
-				Character.valueOf('C'), findItemStack("Advanced Chip"),
+				Character.valueOf('C'), "circuitAdvanced",
 				Character.valueOf('c'), highVoltageCableDescriptor.newItemStack(),
 				Character.valueOf('R'), new ItemStack(Blocks.redstone_block));
 
@@ -6053,7 +6055,7 @@ public class Eln {
 				"DMD",
 				"IcI",
 				Character.valueOf('M'), findItemStack("Advanced Machine Block"),
-				Character.valueOf('C'), findItemStack("Advanced Chip"),
+				Character.valueOf('C'), "circuitAdvanced",
 				Character.valueOf('c'), findItemStack("Advanced Electrical Motor"),
 				Character.valueOf('D'), new ItemStack(Items.diamond),
 				Character.valueOf('I'), "ingotAlloy");
@@ -6072,7 +6074,7 @@ public class Eln {
 				"DMD",
 				"IcI",
 				Character.valueOf('M'), findItemStack("Advanced Machine Block"),
-				Character.valueOf('C'), findItemStack("Advanced Chip"),
+				Character.valueOf('C'), "circuitAdvanced",
 				Character.valueOf('c'), findItemStack("Advanced Electrical Motor"),
 				Character.valueOf('D'), "plateAlloy",
 				Character.valueOf('I'), "ingotAlloy");
@@ -6091,7 +6093,7 @@ public class Eln {
 				"DMD",
 				"DcD",
 				Character.valueOf('M'), findItemStack("Advanced Machine Block"),
-				Character.valueOf('C'), findItemStack("Advanced Chip"),
+				Character.valueOf('C'), "circuitAdvanced",
 				Character.valueOf('c'), findItemStack("Advanced Electrical Motor"),
 				Character.valueOf('D'), "plateAlloy",
 				Character.valueOf('I'), "ingotAlloy");
@@ -6110,7 +6112,7 @@ public class Eln {
 				"cMc",
 				"III",
 				Character.valueOf('M'), findItemStack("Advanced Machine Block"),
-				Character.valueOf('C'), findItemStack("Advanced Chip"),
+				Character.valueOf('C'), "circuitAdvanced",
 				Character.valueOf('c'), findItemStack("Advanced Electrical Motor"),
 				Character.valueOf('I'), "ingotAlloy");
 
@@ -6329,7 +6331,7 @@ public class Eln {
 				"c I",
 				"CI ",
 				"c I",
-				Character.valueOf('C'), findItemStack("Advanced Chip"),
+				Character.valueOf('C'), "circuitAdvanced",
 				Character.valueOf('c'), findItemStack("Cheap Chip"),
 				Character.valueOf('I'), "plateIron",
 				Character.valueOf('R'), new ItemStack(Items.redstone));
@@ -6337,7 +6339,7 @@ public class Eln {
 				"I  ",
 				" IC",
 				"I  ",
-				Character.valueOf('C'), findItemStack("Advanced Chip"),
+				Character.valueOf('C'), "circuitAdvanced",
 				Character.valueOf('I'), "plateIron",
 				Character.valueOf('R'), new ItemStack(Items.redstone));
 
@@ -6345,7 +6347,7 @@ public class Eln {
 				"C I",
 				"CI ",
 				"C I",
-				Character.valueOf('C'), findItemStack("Advanced Chip"),
+				Character.valueOf('C'), "circuitAdvanced",
 				Character.valueOf('c'), findItemStack("Cheap Chip"),
 				Character.valueOf('I'), "plateIron",
 				Character.valueOf('R'), new ItemStack(Items.redstone));
@@ -6353,7 +6355,7 @@ public class Eln {
 				"I D",
 				" IC",
 				"I D",
-				Character.valueOf('C'), findItemStack("Advanced Chip"),
+				Character.valueOf('C'), "circuitAdvanced",
 				Character.valueOf('I'), "plateIron",
 				Character.valueOf('R'), new ItemStack(Items.redstone),
 				Character.valueOf('D'), new ItemStack(Items.diamond));
@@ -6381,7 +6383,7 @@ public class Eln {
 				"RIR",
 				"ICI",
 				"RcR",
-				Character.valueOf('C'), findItemStack("Advanced Chip"),
+				Character.valueOf('C'), "circuitAdvanced",
 				Character.valueOf('c'), findItemStack("Medium Voltage Cable"),
 				Character.valueOf('I'), new ItemStack(Items.iron_ingot),
 				Character.valueOf('R'), new ItemStack(Items.redstone));
@@ -6424,7 +6426,7 @@ public class Eln {
 					"III",
 					"cCR",
 					"III",
-					Character.valueOf('C'), findItemStack("Advanced Chip"),
+					Character.valueOf('C'), "circuitAdvanced",
 					Character.valueOf('c'), findItemStack("High Voltage Cable"),
 					Character.valueOf('I'), new ItemStack(Items.iron_ingot),
 					Character.valueOf('R'), new ItemStack(Items.gold_ingot));
@@ -6438,7 +6440,7 @@ public class Eln {
 					"cIw",
 					"ICI",
 					"WIc",
-					Character.valueOf('C'), findItemStack("Advanced Chip"),
+					Character.valueOf('C'), "circuitAdvanced",
 					Character.valueOf('c'), findItemStack("Signal Cable"),
 					Character.valueOf('I'), new ItemStack(Items.iron_ingot),
 					Character.valueOf('w'), findItemStack("Wireless Signal Receiver"),

--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -4967,7 +4967,7 @@ public class Eln {
 				"ICI",
 				Character.valueOf('R'), new ItemStack(Items.redstone),
 				Character.valueOf('I'), new ItemStack(Items.iron_ingot),
-				Character.valueOf('C'), findItemStack("Cheap Chip"),
+				Character.valueOf('C'), "circuitBasic",
 				Character.valueOf('S'), findItemStack("Signal Antenna"));
 
 		addRecipe(findItemStack("Wireless Signal Repeater"),
@@ -4976,7 +4976,7 @@ public class Eln {
 				"ICI",
 				Character.valueOf('R'), new ItemStack(Items.redstone),
 				Character.valueOf('I'), new ItemStack(Items.iron_ingot),
-				Character.valueOf('C'), findItemStack("Cheap Chip"),
+				Character.valueOf('C'), "circuitBasic",
 				Character.valueOf('S'), findItemStack("Signal Antenna"));
 
 		addRecipe(findItemStack("Wireless Signal Receiver"),
@@ -4984,7 +4984,7 @@ public class Eln {
 				"ICI",
 				Character.valueOf('R'), new ItemStack(Items.redstone),
 				Character.valueOf('I'), new ItemStack(Items.iron_ingot),
-				Character.valueOf('C'), findItemStack("Cheap Chip"),
+				Character.valueOf('C'), "circuitBasic",
 				Character.valueOf('S'), findItemStack("Signal Antenna"));
 
 	}
@@ -5134,7 +5134,7 @@ public class Eln {
 				"IRI",
 				"IcI",
 				Character.valueOf('c'), findItemStack("Copper Cable"),
-				Character.valueOf('R'), findItemStack("Cheap Chip"),
+				Character.valueOf('R'), "circuitBasic",
 				Character.valueOf('I'), new ItemStack(Items.iron_ingot));
 
 		addRecipe(findItemStack("Advanced Energy Meter"),
@@ -5335,7 +5335,7 @@ public class Eln {
 				" I ",
 				Character.valueOf('R'), new ItemStack(Items.redstone),
 				Character.valueOf('I'), new ItemStack(Items.iron_ingot),
-				Character.valueOf('C'), findItemStack("Cheap Chip"));
+				Character.valueOf('C'), "circuitBasic");
 	}
 
 	void recipeLampItem() {
@@ -5448,13 +5448,13 @@ public class Eln {
 		addRecipe(findItemStack("Overvoltage Protection", 4),
 				"SCD",
 				Character.valueOf('S'), findItemStack("Electrical Probe Chip"),
-				Character.valueOf('C'), findItemStack("Cheap Chip"),
+				Character.valueOf('C'), "circuitBasic",
 				Character.valueOf('D'), new ItemStack(Items.redstone));
 
 		addRecipe(findItemStack("Overheating Protection", 4),
 				"SCD",
 				Character.valueOf('S'), findItemStack("Thermal Probe Chip"),
-				Character.valueOf('C'), findItemStack("Cheap Chip"),
+				Character.valueOf('C'), "circuitBasic",
 				Character.valueOf('D'), new ItemStack(Items.redstone));
 
 	}
@@ -5587,7 +5587,7 @@ public class Eln {
 				" T ",
 				" P ",
 				Character.valueOf('T'), findItemStack("Mining Pipe"),
-				Character.valueOf('C'), findItemStack("Cheap Chip"),
+				Character.valueOf('C'), "circuitBasic",
 				Character.valueOf('M'), findItemStack("Electrical Motor"),
 				Character.valueOf('P'), new ItemStack(Items.iron_pickaxe));
 
@@ -5595,7 +5595,7 @@ public class Eln {
 				"RCR",
 				" D ",
 				" d ", Character.valueOf('R'), Items.redstone,
-				Character.valueOf('C'), findItemStack("Cheap Chip"),
+				Character.valueOf('C'), "circuitBasic",
 				Character.valueOf('D'), findItemStack("Cheap Electrical Drill"),
 				Character.valueOf('d'), new ItemStack(Items.diamond));
 
@@ -5616,7 +5616,7 @@ public class Eln {
 				"IGI",
 				"RCR",
 				"IGI",
-				Character.valueOf('C'), findItemStack("Cheap Chip"),
+				Character.valueOf('C'), "circuitBasic",
 				Character.valueOf('R'), new ItemStack(Items.redstone),
 				Character.valueOf('I'), new ItemStack(Items.iron_ingot),
 				Character.valueOf('G'), new ItemStack(Items.gold_ingot));
@@ -6122,7 +6122,7 @@ public class Eln {
 
 		addShapelessRecipe(findItemStack("Electrical Timer"),
 				new ItemStack(Items.repeater),
-				findItemStack("Cheap Chip"));
+				"circuitBasic");
 
 		addRecipe(findItemStack("Signal Processor", 1),
 				"IcI",
@@ -6130,7 +6130,7 @@ public class Eln {
 				"IcI",
 				Character.valueOf('I'), new ItemStack(Items.iron_ingot),
 				Character.valueOf('c'), findItemStack("Signal Cable"),
-				Character.valueOf('C'), findItemStack("Cheap Chip"));
+				Character.valueOf('C'), "circuitBasic");
 	}
 
 	private void recipeElectricalRedstone() {
@@ -6138,13 +6138,13 @@ public class Eln {
 		addRecipe(findItemStack("Redstone-to-Voltage Converter", 1),
 				"TCS",
 				Character.valueOf('S'), findItemStack("Signal Cable"),
-				Character.valueOf('C'), findItemStack("Cheap Chip"),
+				Character.valueOf('C'), "circuitBasic",
 				Character.valueOf('T'), new ItemStack(Blocks.redstone_torch));
 
 		addRecipe(findItemStack("Voltage-to-Redstone Converter", 1),
 				"CTR",
 				Character.valueOf('R'), new ItemStack(Items.redstone),
-				Character.valueOf('C'), findItemStack("Cheap Chip"),
+				Character.valueOf('C'), "circuitBasic",
 				Character.valueOf('T'), new ItemStack(Blocks.redstone_torch));
 
 	}
@@ -6253,7 +6253,7 @@ public class Eln {
 				" r ",
 				Character.valueOf('M'), findItemStack("Machine Block"),
 				Character.valueOf('c'), findItemStack("Signal Cable"),
-				Character.valueOf('C'), findItemStack("Cheap Chip"),
+				Character.valueOf('C'), "circuitBasic",
 				Character.valueOf('a'), findItemStack("Signal Antenna"),
 				Character.valueOf('r'), "itemRubber",
 				Character.valueOf('I'), new ItemStack(Items.iron_ingot),
@@ -6265,7 +6265,7 @@ public class Eln {
 				" R ",
 				Character.valueOf('M'), findItemStack("Machine Block"),
 				Character.valueOf('c'), findItemStack("Signal Cable"),
-				Character.valueOf('C'), findItemStack("Cheap Chip"),
+				Character.valueOf('C'), "circuitBasic",
 				Character.valueOf('a'), findItemStack("Signal Antenna"),
 				Character.valueOf('r'), "itemRubber",
 				Character.valueOf('I'), new ItemStack(Items.iron_ingot),
@@ -6281,7 +6281,7 @@ public class Eln {
 				"RGR",
 				"RCR",
 				Character.valueOf('R'), "itemRubber",
-				Character.valueOf('C'), findItemStack("Cheap Chip"),
+				Character.valueOf('C'), "circuitBasic",
 				Character.valueOf('G'), new ItemStack(Blocks.glass_pane));
 	}
 
@@ -6315,7 +6315,7 @@ public class Eln {
 				"R i",
 				"CI ",
 				"R i",
-				Character.valueOf('C'), findItemStack("Cheap Chip"),
+				Character.valueOf('C'), "circuitBasic",
 				Character.valueOf('i'), new ItemStack(Items.iron_ingot),
 				Character.valueOf('I'), "plateIron",
 				Character.valueOf('R'), new ItemStack(Items.redstone));
@@ -6323,7 +6323,7 @@ public class Eln {
 				"i  ",
 				" IC",
 				"i  ",
-				Character.valueOf('C'), findItemStack("Cheap Chip"),
+				Character.valueOf('C'), "circuitBasic",
 				Character.valueOf('I'), "plateIron",
 				Character.valueOf('i'), new ItemStack(Items.iron_ingot),
 				Character.valueOf('R'), new ItemStack(Items.redstone));
@@ -6332,7 +6332,7 @@ public class Eln {
 				"CI ",
 				"c I",
 				Character.valueOf('C'), "circuitAdvanced",
-				Character.valueOf('c'), findItemStack("Cheap Chip"),
+				Character.valueOf('c'), "circuitBasic",
 				Character.valueOf('I'), "plateIron",
 				Character.valueOf('R'), new ItemStack(Items.redstone));
 		addRecipe(findItemStack("Medium Power Receiver Antenna", 1),
@@ -6348,7 +6348,7 @@ public class Eln {
 				"CI ",
 				"C I",
 				Character.valueOf('C'), "circuitAdvanced",
-				Character.valueOf('c'), findItemStack("Cheap Chip"),
+				Character.valueOf('c'), "circuitBasic",
 				Character.valueOf('I'), "plateIron",
 				Character.valueOf('R'), new ItemStack(Items.redstone));
 		addRecipe(findItemStack("High Power Receiver Antenna", 1),
@@ -6374,7 +6374,7 @@ public class Eln {
 				"RIR",
 				"ICI",
 				"RcR",
-				Character.valueOf('C'), findItemStack("Cheap Chip"),
+				Character.valueOf('C'), "circuitBasic",
 				Character.valueOf('c'), findItemStack("Low Voltage Cable"),
 				Character.valueOf('I'), new ItemStack(Items.iron_ingot),
 				Character.valueOf('R'), new ItemStack(Items.redstone));
@@ -6395,7 +6395,7 @@ public class Eln {
 				"IGG",
 				"E G",
 				"CII",
-				Character.valueOf('C'), findItemStack("Cheap Chip"),
+				Character.valueOf('C'), "circuitBasic",
 				Character.valueOf('E'), findItemStack("Small 50V Tungsten Heating Corp"),
 				Character.valueOf('I'), new ItemStack(Items.iron_ingot),
 				Character.valueOf('G'), new ItemStack(Blocks.glass_pane));
@@ -6408,7 +6408,7 @@ public class Eln {
 					"III",
 					"cCR",
 					"III",
-					Character.valueOf('C'), findItemStack("Cheap Chip"),
+					Character.valueOf('C'), "circuitBasic",
 					Character.valueOf('c'), findItemStack("Low Voltage Cable"),
 					Character.valueOf('I'), new ItemStack(Items.iron_ingot),
 					Character.valueOf('R'), "ingotCopper");
@@ -6417,7 +6417,7 @@ public class Eln {
 					"III",
 					"cCR",
 					"III",
-					Character.valueOf('C'), findItemStack("Cheap Chip"),
+					Character.valueOf('C'), "circuitBasic",
 					Character.valueOf('c'), findItemStack("Medium Voltage Cable"),
 					Character.valueOf('I'), new ItemStack(Items.iron_ingot),
 					Character.valueOf('R'), dicTungstenIngot);


### PR DESCRIPTION
IC2 and Mekanism have Ore Dictionary entries for their circuits, this'll make all the mods equivalent circuits/chips interchangeable in crafting recipes.
