### PR TITLE
Fixes #344 Infinite loop when ray trace hits an unloaded block

### DIFF
--- a/src/main/java/mods/eln/misc/Utils.java
+++ b/src/main/java/mods/eln/misc/Utils.java
@@ -918,11 +918,11 @@ public class Utils {
 		double d = 0;
 
 		while (d < norm) {
-			if (!Utils.isBlockLoaded(world, x, y, z))
-				continue;
-			Block b = Utils.getBlock(world, x, y, z);
-			if (b != null)
-				blockList.add(b);
+			if (Utils.isBlockLoaded(world, x, y, z)) {
+				Block b = Utils.getBlock(world, x, y, z);
+				if (b != null)
+					blockList.add(b);
+			}
 
 			x += dx;
 			y += dy;


### PR DESCRIPTION
The `x, y, z, d` variables weren't being updated when the block wasn't and it was causing an infinite loop
