### PR TITLE
Fixed NPE when no wireless spots or txs are selected as best

### DIFF
--- a/src/main/java/mods/eln/sixnode/wirelesssignal/WirelessUtils.java
+++ b/src/main/java/mods/eln/sixnode/wirelesssignal/WirelessUtils.java
@@ -73,6 +73,8 @@ public class WirelessUtils {
 						strength = b.getRange() - getVirtualDistance(b.getCoordonate(), from.getCoordonate(), b.getCoordonate().trueDistanceTo(from.getCoordonate()));
 					getTx(b, txSet, txStrength, spotSet, false, strength);
 					spots.remove(best);
+				} else if(best == null) {
+					break;
 				} else {
 					IWirelessSignalTx tx = (IWirelessSignalTx) best;
 


### PR DESCRIPTION
This fixes this crash that stops the server:

``` java
Description: Exception in server tick loop

java.lang.NullPointerException: Exception in server tick loop
        at mods.eln.sixnode.wirelesssignal.WirelessUtils.getTx(WirelessUtils.java:80)
        at mods.eln.sixnode.wirelesssignal.WirelessUtils.getTx(WirelessUtils.java:20)
        at mods.eln.sixnode.wirelesssignal.rx.WirelessSignalRxProcess.process(WirelessSignalRxProcess.java:36)
        at mods.eln.sim.Simulator.tick(Simulator.java:397)
        at cpw.mods.fml.common.eventhandler.ASMEventHandler_36_Simulator_tick_ServerTickEvent.invoke(.dynamic)
        at cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54)
        at cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140)
        at cpw.mods.fml.common.FMLCommonHandler.onPreServerTick(FMLCommonHandler.java:264)
        at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:797)
        at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:669)
        at java.lang.Thread.run(Thread.java:745)
```
