### PR TITLE
Useless parentheses around expressions should be removed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 
-install:
-  - pip install transifex-client
+python:
+  - "3.5"
 
 after_success:
   - ./script/transifex.sh

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,29 @@
+# This is intended to be used with nix-shell.
+# It provides a dev environment, in which gradle and 'gradle runClient' work.
+
+with import <nixpkgs> {};
+
+let
+  devenvSetup = with xlibs; stdenv.mkDerivation {
+    name = "devenvSetup";
+
+    phases = "installPhase";
+
+    installPhase = ''
+      mkdir -p $out/nix-support
+
+      cat > $out/nix-support/setup-hook <<EOF
+        export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:${libX11}/lib/:${libXext}/lib/:${libXcursor}/lib/:${libXrandr}/lib/:${libXxf86vm}/lib/:${mesa}/lib/:${openal}/lib/
+      EOF
+    '';
+  };
+in
+
+{
+  devenv = stdenv.mkDerivation {
+    name = "devenv";
+
+    buildInputs = [ gradle jdk devenvSetup ];
+  };
+
+}

--- a/script/transifex.sh
+++ b/script/transifex.sh
@@ -9,11 +9,20 @@
 if [ "$TRAVIS_REPO_SLUG" == "Electrical-Age/ElectricalAge" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "1.7.10-MNA" ]
 then
 
+  echo "Installing the transifex client"
+  python --version
+  pip --version
+  pip install --upgrade pip
+  pip --version
+  
+  # See https://github.com/transifex/transifex-client/issues/113  
+  # pip install transifex-client
+  pip install git+git://github.com/transifex/transifex-client.git@master
+
   echo "Generating the latest language source file"
   ./gradlew updateMasterLanguageFile
 
   echo "Submitting the generated translation source file to Transifex"
-  # pip install transifex-client
   # Write .transifexrc file
   echo "[https://www.transifex.com]
 hostname = https://www.transifex.com

--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -715,7 +715,7 @@ public class Eln {
 		}
 
 		MinecraftForge.EVENT_BUS.register(new ElnForgeEventsHandler());
-		FMLCommonHandler.instance().bus().register((new ElnFMLEventsHandler()));
+		FMLCommonHandler.instance().bus().register(new ElnFMLEventsHandler());
 
 		Utils.println("Electrical age init done");
 	}

--- a/src/main/java/mods/eln/cable/CableRender.java
+++ b/src/main/java/mods/eln/cable/CableRender.java
@@ -104,7 +104,7 @@ public class CableRender {
 					Direction otherDirection = side.getInverse();
 					LRDU otherLRDU = otherDirection.getLRDUGoingTo(sideLrdu).inverse();
 					CableRenderDescriptor render = entity.getCableRender(sideLrdu, sideLrdu.getLRDUGoingTo(side));
-					NodeBlockEntity otherNode = ((NodeBlockEntity)otherTileEntity);
+					NodeBlockEntity otherNode = (NodeBlockEntity)otherTileEntity;
 					CableRenderDescriptor otherRender = otherNode.getCableRender(otherDirection, otherLRDU);
 
 					if(render == null) {
@@ -262,7 +262,7 @@ public class CableRender {
 
 					if(render == null)
 						continue; 
-					NodeBlockEntity otherNode =  ((NodeBlockEntity)otherTileEntity);
+					NodeBlockEntity otherNode = (NodeBlockEntity)otherTileEntity;
 					CableRenderDescriptor otherRender = otherNode.getCableRender(otherDirection, otherLRDU);
 					
 					if(otherRender == null) {

--- a/src/main/java/mods/eln/gui/SharedFloat.java
+++ b/src/main/java/mods/eln/gui/SharedFloat.java
@@ -18,7 +18,7 @@ public class SharedFloat {
 		float readed;
 		try {
 			readed = stream.readFloat();
-			if(syncBoot || (syncValue != readed)) {
+			if(syncBoot || syncValue != readed) {
 				syncBoot = true;
 				syncValue = readed;
 			}

--- a/src/main/java/mods/eln/misc/BasicContainer.java
+++ b/src/main/java/mods/eln/misc/BasicContainer.java
@@ -108,7 +108,7 @@ public class BasicContainer extends Container {
 
 				itemstack1 = slot.getStack();
 
-				if ((slot.isItemValid(par1ItemStack)) && itemstack1 != null && itemstack1.getItem() == par1ItemStack.getItem() && (!par1ItemStack.getHasSubtypes() || par1ItemStack.getItemDamage() == itemstack1.getItemDamage()) && ItemStack.areItemStackTagsEqual(par1ItemStack, itemstack1)) {
+				if (slot.isItemValid(par1ItemStack) && itemstack1 != null && itemstack1.getItem() == par1ItemStack.getItem() && (!par1ItemStack.getHasSubtypes() || par1ItemStack.getItemDamage() == itemstack1.getItemDamage()) && ItemStack.areItemStackTagsEqual(par1ItemStack, itemstack1)) {
 					int l = itemstack1.stackSize + par1ItemStack.stackSize;
 					int maxSize = Math.min(slot.getSlotStackLimit(), par1ItemStack.getMaxStackSize());
 					if (l <= maxSize) {
@@ -143,7 +143,7 @@ public class BasicContainer extends Container {
 				slot = (Slot) this.inventorySlots.get(k);
 				itemstack1 = slot.getStack();
 
-				if (itemstack1 == null && (slot.isItemValid(par1ItemStack))) {
+				if (itemstack1 == null && slot.isItemValid(par1ItemStack)) {
 					int l = par1ItemStack.stackSize;
 					int maxSize = Math.min(slot.getSlotStackLimit(), par1ItemStack.getMaxStackSize());
 					if (l <= maxSize) {

--- a/src/main/java/mods/eln/misc/Utils.java
+++ b/src/main/java/mods/eln/misc/Utils.java
@@ -688,7 +688,7 @@ public class Utils {
 	 */
 
 	public static void serialiseItemStack(DataOutputStream stream, ItemStack stack) throws IOException {
-		if ((stack) == null) {
+		if (stack == null) {
 			stream.writeShort(-1);
 			stream.writeShort(-1);
 		} else {
@@ -1202,7 +1202,7 @@ public class Utils {
 				ShapedOreRecipe rr = (ShapedOreRecipe) r;
 				for (Object o : ((ShapedOreRecipe) r).getInput()) {
 					if (o instanceof List) {
-						stacks.addAll(((List) o));
+						stacks.addAll((List) o);
 					}
 
 					if (o instanceof ItemStack) {
@@ -1214,7 +1214,7 @@ public class Utils {
 				ShapelessOreRecipe rr = (ShapelessOreRecipe) r;
 				for (Object o : ((ShapelessOreRecipe) r).getInput()) {
 					if (o instanceof List) {
-						stacks.addAll(((List) o));
+						stacks.addAll((List) o);
 					}
 
 					if (o instanceof ItemStack) {

--- a/src/main/java/mods/eln/sixnode/diode/DiodeElement.java
+++ b/src/main/java/mods/eln/sixnode/diode/DiodeElement.java
@@ -69,7 +69,7 @@ public class DiodeElement extends SixNodeElement {
 	@Override
 	public void writeToNBT(NBTTagCompound nbt) {
 		super.writeToNBT(nbt);
-		nbt.setByte("front", (byte) ((front.toInt() << 0)));
+		nbt.setByte("front", (byte) (front.toInt() << 0));
 	}
 
 	@Override
@@ -105,7 +105,7 @@ public class DiodeElement extends SixNodeElement {
 	public void networkSerialize(DataOutputStream stream) {
 		super.networkSerialize(stream);
 		try {
-			stream.writeByte((front.toInt() << 4));
+			stream.writeByte(front.toInt() << 4);
 			stream.writeShort((short) ((anodeLoad.getU()) * NodeBase.networkSerializeUFactor));
 			stream.writeShort((short) ((catodeLoad.getU()) * NodeBase.networkSerializeUFactor));
 			stream.writeShort((short) (anodeLoad.getCurrent() * NodeBase.networkSerializeIFactor));

--- a/src/main/java/mods/eln/sixnode/electricalbreaker/ElectricalBreakerElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalbreaker/ElectricalBreakerElement.java
@@ -83,7 +83,7 @@ public class ElectricalBreakerElement extends SixNodeElement {
 	@Override
 	public void writeToNBT(NBTTagCompound nbt) {
 		super.writeToNBT(nbt);
-		nbt.setByte("front", (byte) ((front.toInt() << 0)));
+		nbt.setByte("front", (byte) (front.toInt() << 0));
 		nbt.setBoolean("switchState", switchState);
 		nbt.setFloat("voltageMax", voltageMax);
         nbt.setFloat("voltageMin", voltageMin);
@@ -125,8 +125,8 @@ public class ElectricalBreakerElement extends SixNodeElement {
 		super.networkSerialize(stream);
 		try {
 			stream.writeBoolean(switchState);
-	    	stream.writeFloat((voltageMax));
-	    	stream.writeFloat((voltageMin));
+	    	stream.writeFloat(voltageMax);
+	    	stream.writeFloat(voltageMin);
 
 	    	Utils.serialiseItemStack(stream, inventory.getStackInSlot(ElectricalBreakerContainer.cableSlotId));
 		} catch (IOException e) {

--- a/src/main/java/mods/eln/sixnode/electricalcable/ElectricalCableElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalcable/ElectricalCableElement.java
@@ -119,7 +119,7 @@ public class ElectricalCableElement extends SixNodeElement {
 	public void networkSerialize(DataOutputStream stream) {
 		super.networkSerialize(stream);
 		try {
-			stream.writeByte((color << 4));
+			stream.writeByte(color << 4);
 	    /*	stream.writeShort((short) (electricalLoad.Uc * NodeBase.networkSerializeUFactor));
 	    	stream.writeShort((short) (electricalLoad.getCurrent() * NodeBase.networkSerializeIFactor));
 	    	stream.writeShort((short) (thermalLoad.Tc * NodeBase.networkSerializeTFactor));*/

--- a/src/main/java/mods/eln/sixnode/electricaldatalogger/ElectricalDataLoggerProcess.java
+++ b/src/main/java/mods/eln/sixnode/electricaldatalogger/ElectricalDataLoggerProcess.java
@@ -22,7 +22,7 @@ public class ElectricalDataLoggerProcess implements IProcess {
 		//p.add("A");
 		if (!e.pause) {
 			e.timeToNextSample -= time;
-			byte value = ((byte)(e.inputGate.getNormalized() * 255.5 - 128));
+			byte value = (byte) (e.inputGate.getNormalized() * 255.5 - 128);
 			e.sampleStack += value;
 			e.sampleStackNbr++;
 		}

--- a/src/main/java/mods/eln/sixnode/electricalgatesource/ElectricalGateSourceElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalgatesource/ElectricalGateSourceElement.java
@@ -117,7 +117,7 @@ public class ElectricalGateSourceElement extends SixNodeElement {
 	public void networkSerialize(DataOutputStream stream) {
 		super.networkSerialize(stream);
 		try {
-			stream.writeByte((front.toInt() << 4));
+			stream.writeByte(front.toInt() << 4);
 			stream.writeFloat((float) outputGateProcess.getU());
 		} catch (IOException e) {
 			e.printStackTrace();

--- a/src/main/java/mods/eln/sixnode/electricallightsensor/ElectricalLightSensorSlowProcess.java
+++ b/src/main/java/mods/eln/sixnode/electricallightsensor/ElectricalLightSensorSlowProcess.java
@@ -32,7 +32,7 @@ public class ElectricalLightSensorSlowProcess implements IProcess {
 			World world = coord.world();
 			int light = 0;
 			//if(element.descriptor.dayLightOnly) {
-		        if ((!world.provider.hasNoSky)) {
+		        if (!world.provider.hasNoSky) {
 		            int i1 = world.getSavedLightValue(EnumSkyBlock.Sky, coord.x, coord.y, coord.z) - world.skylightSubtracted;
 		            i1 = Math.max(0, i1);
 		            float f = world.getCelestialAngleRadians(1.0F);

--- a/src/main/java/mods/eln/sixnode/electricalredstoneinput/ElectricalRedstoneInputElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalredstoneinput/ElectricalRedstoneInputElement.java
@@ -57,7 +57,7 @@ public class ElectricalRedstoneInputElement extends SixNodeElement {
 	@Override
 	public void writeToNBT(NBTTagCompound nbt) {
 		super.writeToNBT(nbt);
-		nbt.setByte("front", (byte)((front.toInt() << 0)));
+		nbt.setByte("front", (byte) (front.toInt() << 0));
 	}
 
 	@Override

--- a/src/main/java/mods/eln/sixnode/electricalredstoneoutput/ElectricalRedstoneOutputElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalredstoneoutput/ElectricalRedstoneOutputElement.java
@@ -67,7 +67,7 @@ public class ElectricalRedstoneOutputElement extends SixNodeElement {
 	@Override
 	public void writeToNBT(NBTTagCompound nbt) {
 		super.writeToNBT(nbt);
-		nbt.setByte("front", (byte)((front.toInt() << 0)));
+		nbt.setByte("front", (byte) (front.toInt() << 0));
         nbt.setInteger("redstoneValue", redstoneValue);
 	}
 

--- a/src/main/java/mods/eln/sixnode/electricalrelay/ElectricalRelayElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalrelay/ElectricalRelayElement.java
@@ -85,7 +85,7 @@ public class ElectricalRelayElement extends SixNodeElement {
 	@Override
 	public void writeToNBT(NBTTagCompound nbt) {
 		super.writeToNBT(nbt);
-		nbt.setByte("front", (byte)((front.toInt() << 0)));
+		nbt.setByte("front", (byte) (front.toInt() << 0));
 		nbt.setBoolean("switchState", switchState);
 		nbt.setBoolean("defaultOutput", defaultOutput);
 	}

--- a/src/main/java/mods/eln/sixnode/electricalswitch/ElectricalSwitchElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalswitch/ElectricalSwitchElement.java
@@ -74,7 +74,7 @@ public class ElectricalSwitchElement extends SixNodeElement {
 	@Override
 	public void writeToNBT(NBTTagCompound nbt) {
 		super.writeToNBT(nbt);
-		nbt.setByte("front", (byte)((front.toInt() << 0)));
+		nbt.setByte("front", (byte) (front.toInt() << 0));
 		nbt.setBoolean("switchState", switchState);
 	}
 
@@ -115,8 +115,8 @@ public class ElectricalSwitchElement extends SixNodeElement {
 		super.networkSerialize(stream);
 		try {
 			stream.writeBoolean(switchState);
-	    	stream.writeShort((short)((aLoad.getU()) * NodeBase.networkSerializeUFactor));
-	    	stream.writeShort((short)((bLoad.getU()) * NodeBase.networkSerializeUFactor));
+	    	stream.writeShort((short)(aLoad.getU() * NodeBase.networkSerializeUFactor));
+	    	stream.writeShort((short)(bLoad.getU() * NodeBase.networkSerializeUFactor));
 	    	stream.writeShort((short)(aLoad.getCurrent() * NodeBase.networkSerializeIFactor));
 	    	//stream.writeShort((short)(thermalLoad.Tc * NodeBase.networkSerializeTFactor));
 	    	stream.writeShort(0);

--- a/src/main/java/mods/eln/sixnode/electricaltimeout/ElectricalTimeoutElement.java
+++ b/src/main/java/mods/eln/sixnode/electricaltimeout/ElectricalTimeoutElement.java
@@ -63,7 +63,7 @@ public class ElectricalTimeoutElement extends SixNodeElement {
 	@Override
 	public void writeToNBT(NBTTagCompound nbt) {
 		super.writeToNBT(nbt);
-		nbt.setByte("front", (byte)((front.toInt() << 0)));
+		nbt.setByte("front", (byte) (front.toInt() << 0));
 		nbt.setFloat("timeOutValue", (float) timeOutValue);
 		nbt.setFloat("timeOutCounter", (float) timeOutCounter);
 	}

--- a/src/main/java/mods/eln/sixnode/electricalvumeter/ElectricalVuMeterElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalvumeter/ElectricalVuMeterElement.java
@@ -47,7 +47,7 @@ public class ElectricalVuMeterElement extends SixNodeElement {
 	@Override
 	public void writeToNBT(NBTTagCompound nbt) {
 		super.writeToNBT(nbt);
-		nbt.setByte("front", (byte)((front.toInt() << 0)));
+		nbt.setByte("front", (byte) (front.toInt() << 0));
 	}
 
 	@Override
@@ -81,7 +81,7 @@ public class ElectricalVuMeterElement extends SixNodeElement {
 	public void networkSerialize(DataOutputStream stream) {
 		super.networkSerialize(stream);
 		try {
-			stream.writeByte((front.toInt() << 4));
+			stream.writeByte(front.toInt() << 4);
 	    	stream.writeFloat((float)(inputGate.getU() / Eln.instance.SVU));
 		} catch (IOException e) {
 			e.printStackTrace();

--- a/src/main/java/mods/eln/sixnode/electricasensor/ElectricalSensorElement.java
+++ b/src/main/java/mods/eln/sixnode/electricasensor/ElectricalSensorElement.java
@@ -100,7 +100,7 @@ public class ElectricalSensorElement extends SixNodeElement {
 	@Override
 	public void writeToNBT(NBTTagCompound nbt) {
 		super.writeToNBT(nbt);
-		nbt.setByte("front", (byte) ((front.toInt() << 0)));
+		nbt.setByte("front", (byte) (front.toInt() << 0));
 		nbt.setByte("typeOfSensor", (byte) typeOfSensor);
 		nbt.setFloat("lowValue", lowValue);
 		nbt.setFloat("highValue", highValue);

--- a/src/main/java/mods/eln/sixnode/groundcable/GroundCableElement.java
+++ b/src/main/java/mods/eln/sixnode/groundcable/GroundCableElement.java
@@ -97,7 +97,7 @@ public class GroundCableElement extends SixNodeElement {
 	public void networkSerialize(DataOutputStream stream) {
 		super.networkSerialize(stream);
 		try {
-			stream.writeByte((color << 4));
+			stream.writeByte(color << 4);
 			Utils.serialiseItemStack(stream, inventory.getStackInSlot(GroundCableContainer.cableSlotId));
 		} catch (IOException e) {
 			e.printStackTrace();

--- a/src/main/java/mods/eln/transparentnode/autominer/AutoMinerRender.java
+++ b/src/main/java/mods/eln/transparentnode/autominer/AutoMinerRender.java
@@ -163,7 +163,7 @@ public class AutoMinerRender extends TransparentNodeElementRender {
 				float camAlpha;
 				switch (front) {
                     default:
-                    case XN: camAlpha = (float)(Math.PI); break;
+                    case XN: camAlpha = (float) Math.PI; break;
                     case XP: camAlpha = 0; break;
                     case ZN: camAlpha = (float)(-Math.PI / 2); break;
                     case ZP: camAlpha = (float)(Math.PI / 2); break;

--- a/src/main/java/mods/eln/transparentnode/battery/BatteryDescriptor.java
+++ b/src/main/java/mods/eln/transparentnode/battery/BatteryDescriptor.java
@@ -178,7 +178,7 @@ public class BatteryDescriptor extends TransparentNodeDescriptor  {
 	}
 
 	public static BatteryDescriptor getDescriptorFrom(ItemStack itemStack) {
-		return list[(itemStack.getItemDamage()) & 0x7];
+		return list[itemStack.getItemDamage() & 0x7];
 	}
 	
 	@Override

--- a/src/main/java/mods/eln/transparentnode/waterturbine/WaterTurbineRender.java
+++ b/src/main/java/mods/eln/transparentnode/waterturbine/WaterTurbineRender.java
@@ -55,7 +55,7 @@ public class WaterTurbineRender extends TransparentNodeElementRender {
 
 		// Utils.println(powerFactorFilter.get());
 		float alphaN_1 = alpha;
-		alpha += deltaT * descriptor.speed * (powerFactorFilter.get());
+		alpha += deltaT * descriptor.speed * powerFactorFilter.get();
 		if (alpha > 360)
 			alpha -= 360;
 		if (alpha < 0)


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.
