### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 
-install:
-  - pip install transifex-client
+python:
+  - "3.5"
 
 after_success:
   - ./script/transifex.sh

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,29 @@
+# This is intended to be used with nix-shell.
+# It provides a dev environment, in which gradle and 'gradle runClient' work.
+
+with import <nixpkgs> {};
+
+let
+  devenvSetup = with xlibs; stdenv.mkDerivation {
+    name = "devenvSetup";
+
+    phases = "installPhase";
+
+    installPhase = ''
+      mkdir -p $out/nix-support
+
+      cat > $out/nix-support/setup-hook <<EOF
+        export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:${libX11}/lib/:${libXext}/lib/:${libXcursor}/lib/:${libXrandr}/lib/:${libXxf86vm}/lib/:${mesa}/lib/:${openal}/lib/
+      EOF
+    '';
+  };
+in
+
+{
+  devenv = stdenv.mkDerivation {
+    name = "devenv";
+
+    buildInputs = [ gradle jdk devenvSetup ];
+  };
+
+}

--- a/script/transifex.sh
+++ b/script/transifex.sh
@@ -9,11 +9,20 @@
 if [ "$TRAVIS_REPO_SLUG" == "Electrical-Age/ElectricalAge" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "1.7.10-MNA" ]
 then
 
+  echo "Installing the transifex client"
+  python --version
+  pip --version
+  pip install --upgrade pip
+  pip --version
+  
+  # See https://github.com/transifex/transifex-client/issues/113  
+  # pip install transifex-client
+  pip install git+git://github.com/transifex/transifex-client.git@master
+
   echo "Generating the latest language source file"
   ./gradlew updateMasterLanguageFile
 
   echo "Submitting the generated translation source file to Transifex"
-  # pip install transifex-client
   # Write .transifexrc file
   echo "[https://www.transifex.com]
 hostname = https://www.transifex.com

--- a/src/main/java/li/cil/oc/util/SideTracker.java
+++ b/src/main/java/li/cil/oc/util/SideTracker.java
@@ -8,6 +8,9 @@ import java.util.Set;
 public final class SideTracker {
     private static final Set<Thread> serverThreads = Collections.newSetFromMap(new java.util.WeakHashMap<Thread, Boolean>());
 
+    private SideTracker() {
+    }
+
     public static void addServerThread() {
         serverThreads.add(Thread.currentThread());
     }

--- a/src/main/java/mods/eln/cable/CableRender.java
+++ b/src/main/java/mods/eln/cable/CableRender.java
@@ -13,6 +13,8 @@ import net.minecraft.tileentity.TileEntity;
 import org.lwjgl.opengl.GL11;
 
 public class CableRender {
+	private CableRender() {
+	}
 	/*
 	static final int connectionStandard = 0;	
 	static final int connectionInternal = 1;

--- a/src/main/java/mods/eln/i18n/LanguageFileGenerator.java
+++ b/src/main/java/mods/eln/i18n/LanguageFileGenerator.java
@@ -10,6 +10,9 @@ import java.util.Set;
 class LanguageFileGenerator {
     private static final String FILE_HEADER = "#<ELN_LANGFILE_V1_1>\n";
 
+    private LanguageFileGenerator() {
+    }
+
     public static void updateFile(final File file, final Map<String, Set<TranslationItem>> strings,
                                   final Properties existingTranslations) throws IOException {
         final FileWriter writer = new FileWriter(file);

--- a/src/main/java/mods/eln/i18n/LanguageFileUpdater.java
+++ b/src/main/java/mods/eln/i18n/LanguageFileUpdater.java
@@ -8,6 +8,9 @@ import java.util.Properties;
 import java.util.Set;
 
 class LanguageFileUpdater {
+    private LanguageFileUpdater() {
+    }
+
     private static void updateFile(final File languageFile, final Map<String, Set<TranslationItem>> stringsToTranslate)
         throws IOException {
         // Parse the existing translations from the language file.

--- a/src/main/java/mods/eln/i18n/SourceCodeParser.java
+++ b/src/main/java/mods/eln/i18n/SourceCodeParser.java
@@ -12,6 +12,9 @@ class SourceCodeParser {
         Pattern.compile("TR_([A-Z]*)\\s*\\(\\s*(?:I18N.)?Type.(.*?)\\s*,\\s\"(.*?)\"\\s*\\)");
     private static final String MULTIPLE_LOCATIONS = "Appearing in multiple source files";
 
+    private SourceCodeParser() {
+    }
+
     public static Map<String, Set<TranslationItem>> parseSourceFolder(final File file) throws IOException {
         Map<String, Set<TranslationItem>> strings = new TreeMap<String,Set<TranslationItem>>();
         strings.put(MULTIPLE_LOCATIONS, new TreeSet<TranslationItem>());

--- a/src/main/java/mods/eln/misc/DescriptorManager.java
+++ b/src/main/java/mods/eln/misc/DescriptorManager.java
@@ -5,7 +5,10 @@ import java.util.HashMap;
 public class DescriptorManager {
 
 	static HashMap<Object, Object> map = new HashMap<Object, Object>();
-	
+
+	private DescriptorManager() {
+	}
+
 	public static void put(Object key, Object value){
 		map.put(key, value);
 	}

--- a/src/main/java/mods/eln/misc/Utils.java
+++ b/src/main/java/mods/eln/misc/Utils.java
@@ -75,6 +75,9 @@ public class Utils {
 
 	private static int uuid = 1;
 
+	private Utils() {
+	}
+
 	public static double rand(double min, double max) {
 		return random.nextDouble() * (max - min) + min;
 	}

--- a/src/main/java/mods/eln/misc/UtilsClient.java
+++ b/src/main/java/mods/eln/misc/UtilsClient.java
@@ -49,6 +49,9 @@ public class UtilsClient {
 
     final static ResourceLocation whiteTexture = new ResourceLocation("eln", "sprites/cable.png");
 
+    private UtilsClient() {
+    }
+
     public static float distanceFromClientPlayer(World world, int xCoord, int yCoord, int zCoord) {
         EntityClientPlayerMP player = Minecraft.getMinecraft().thePlayer;
 

--- a/src/main/java/mods/eln/sixnode/wirelesssignal/WirelessUtils.java
+++ b/src/main/java/mods/eln/sixnode/wirelesssignal/WirelessUtils.java
@@ -13,6 +13,9 @@ import java.util.Map.Entry;
 
 public class WirelessUtils {
 
+	private WirelessUtils() {
+	}
+
 	public static void getTx(IWirelessSignalSpot root, HashMap<String, HashSet<IWirelessSignalTx>> txSet, HashMap<IWirelessSignalTx, Double> txStrength) {
 		HashSet<IWirelessSignalSpot> spotSet = new HashSet<IWirelessSignalSpot>();
 		txSet.clear();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.
