### PR TITLE
use Java collection interfaces rather than specific implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 
-install:
-  - pip install transifex-client
+python:
+  - "3.5"
 
 after_success:
   - ./script/transifex.sh

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,29 @@
+# This is intended to be used with nix-shell.
+# It provides a dev environment, in which gradle and 'gradle runClient' work.
+
+with import <nixpkgs> {};
+
+let
+  devenvSetup = with xlibs; stdenv.mkDerivation {
+    name = "devenvSetup";
+
+    phases = "installPhase";
+
+    installPhase = ''
+      mkdir -p $out/nix-support
+
+      cat > $out/nix-support/setup-hook <<EOF
+        export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:${libX11}/lib/:${libXext}/lib/:${libXcursor}/lib/:${libXrandr}/lib/:${libXxf86vm}/lib/:${mesa}/lib/:${openal}/lib/
+      EOF
+    '';
+  };
+in
+
+{
+  devenv = stdenv.mkDerivation {
+    name = "devenv";
+
+    buildInputs = [ gradle jdk devenvSetup ];
+  };
+
+}

--- a/script/transifex.sh
+++ b/script/transifex.sh
@@ -9,11 +9,20 @@
 if [ "$TRAVIS_REPO_SLUG" == "Electrical-Age/ElectricalAge" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "1.7.10-MNA" ]
 then
 
+  echo "Installing the transifex client"
+  python --version
+  pip --version
+  pip install --upgrade pip
+  pip --version
+  
+  # See https://github.com/transifex/transifex-client/issues/113  
+  # pip install transifex-client
+  pip install git+git://github.com/transifex/transifex-client.git@master
+
   echo "Generating the latest language source file"
   ./gradlew updateMasterLanguageFile
 
   echo "Submitting the generated translation source file to Transifex"
-  # pip install transifex-client
   # Write .transifexrc file
   echo "[https://www.transifex.com]
 hostname = https://www.transifex.com

--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -312,7 +312,7 @@ public class Eln {
 
 		Utils.println(Version.print());
 
-		ArrayList<ISymbole> symboleList = new ArrayList<ISymbole>();
+		List<ISymbole> symboleList = new ArrayList<ISymbole>();
 		symboleList.add(new ConstSymbole("A", 0.1));
 		symboleList.add(new ConstSymbole("B", 0.2));
 		symboleList.add(new ConstSymbole("C", 0.3));

--- a/src/main/java/mods/eln/entity/ReplicatoCableAI.java
+++ b/src/main/java/mods/eln/entity/ReplicatoCableAI.java
@@ -1,6 +1,7 @@
 package mods.eln.entity;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 
 import mods.eln.Eln;
@@ -51,7 +52,7 @@ public class ReplicatoCableAI extends EntityAIBase implements ITimeRemoverObserv
 	@Override
 	public boolean shouldExecute() {
 		//Utils.println("LookingForCableAi");
-		ArrayList<NodeBase> nodes = NodeManager.instance.getNodes();
+		List<NodeBase> nodes = NodeManager.instance.getNodes();
 		if(nodes.size() == 0) return false;
 		for(int idx = 0; idx < lookingPerUpdate; idx++) {
 			NodeBase node = nodes.get(rand.nextInt(nodes.size()));

--- a/src/main/java/mods/eln/generic/GenericItemUsingDamageSlot.java
+++ b/src/main/java/mods/eln/generic/GenericItemUsingDamageSlot.java
@@ -6,6 +6,7 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class GenericItemUsingDamageSlot extends SlotWithSkin implements ISlotWithComment {
 
@@ -58,7 +59,7 @@ public class GenericItemUsingDamageSlot extends SlotWithSkin implements ISlotWit
     }
 
 	@Override
-	public void getComment(ArrayList<String> list) {
+	public void getComment(List<String> list) {
 		for(String str : comment)
 			list.add(str);
 	}

--- a/src/main/java/mods/eln/ghost/GhostManager.java
+++ b/src/main/java/mods/eln/ghost/GhostManager.java
@@ -21,8 +21,8 @@ public class GhostManager extends WorldSavedData {
 		super(par1Str);
 	}
 
-	Hashtable<Coordonate, GhostElement> ghostTable = new Hashtable<Coordonate, GhostElement>();
-	Hashtable<Coordonate, GhostObserver> observerTable = new Hashtable<Coordonate, GhostObserver>();
+	Map<Coordonate, GhostElement> ghostTable = new Hashtable<Coordonate, GhostElement>();
+	Map<Coordonate, GhostObserver> observerTable = new Hashtable<Coordonate, GhostObserver>();
 
 	public void clear() {
 		ghostTable.clear();

--- a/src/main/java/mods/eln/gui/GuiHelper.java
+++ b/src/main/java/mods/eln/gui/GuiHelper.java
@@ -300,7 +300,7 @@ public class GuiHelper {
         GL11.glEnable(GL11.GL_TEXTURE_2D);
     }
 
-	public int getHoveringTextWidth(ArrayList<String> comment, FontRenderer fontRenderer) {
+	public int getHoveringTextWidth(List<String> comment, FontRenderer fontRenderer) {
 		int strWidth = 0;
 		for(String str : comment) {
 			int size = fontRenderer.getStringWidth(str);
@@ -309,7 +309,7 @@ public class GuiHelper {
 		return strWidth +5;
 	}
 
-	public int getHoveringTextHeight(ArrayList<String> comment,FontRenderer fontRenderer) {
+	public int getHoveringTextHeight(List<String> comment, FontRenderer fontRenderer) {
 		return comment.size() * 9 - 4;
 	}
 	

--- a/src/main/java/mods/eln/gui/ISlotWithComment.java
+++ b/src/main/java/mods/eln/gui/ISlotWithComment.java
@@ -1,7 +1,7 @@
 package mods.eln.gui;
 
-import java.util.ArrayList;
+import java.util.List;
 
 public interface ISlotWithComment {
-	void getComment(ArrayList<String> list);
+	void getComment(List<String> list);
 }

--- a/src/main/java/mods/eln/gui/ItemStackFilter.java
+++ b/src/main/java/mods/eln/gui/ItemStackFilter.java
@@ -7,6 +7,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class ItemStackFilter {
 
@@ -39,7 +40,7 @@ public class ItemStackFilter {
 	}
 
 	public static ItemStackFilter[] OreDict(String name) {
-		final ArrayList<ItemStack> ores = OreDictionary.getOres(name);
+		final List<ItemStack> ores = OreDictionary.getOres(name);
 		ItemStackFilter[] filters = new ItemStackFilter[ores.size()];
 		for (int i = 0; i < ores.size(); i++) {
 			filters[i] = new ItemStackFilter(ores.get(i).getItem(), 0xff, ores.get(i).getItemDamage());

--- a/src/main/java/mods/eln/gui/SlotWithSkinAndComment.java
+++ b/src/main/java/mods/eln/gui/SlotWithSkinAndComment.java
@@ -1,6 +1,7 @@
 package mods.eln.gui;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
@@ -22,7 +23,7 @@ public class SlotWithSkinAndComment extends Slot implements ISlotSkin, ISlotWith
 	}
 
 	@Override
-	public void getComment(ArrayList<String> list) {
+	public void getComment(List<String> list) {
 		for(String str : comment)
 			list.add(str);
 	}

--- a/src/main/java/mods/eln/item/electricalinterface/ItemEnergyInventoryProcess.java
+++ b/src/main/java/mods/eln/item/electricalinterface/ItemEnergyInventoryProcess.java
@@ -3,6 +3,7 @@ package mods.eln.item.electricalinterface;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 
 import mods.eln.Eln;
 import mods.eln.misc.Utils;
@@ -183,7 +184,7 @@ public class ItemEnergyInventoryProcess implements IProcess {
 		}
 	}
 
-	Element getElement(ArrayList<Element> list, int priority) {
+	Element getElement(List<Element> list, int priority) {
 
 		for (Element e : list) {
 			if (priority == e.p) {
@@ -193,7 +194,7 @@ public class ItemEnergyInventoryProcess implements IProcess {
 		return null;
 	}
 
-	Element getMin(ArrayList<Element> list) {
+	Element getMin(List<Element> list) {
 		Element find = null;
 		for (Element e : list) {
 			if (find == null || find.p > e.p) {
@@ -203,7 +204,7 @@ public class ItemEnergyInventoryProcess implements IProcess {
 		return find;
 	}
 
-	Element getMax(ArrayList<Element> list) {
+	Element getMax(List<Element> list) {
 		Element find = null;
 		for (Element e : list) {
 			if (find == null || find.p < e.p) {

--- a/src/main/java/mods/eln/misc/LiveDataManager.java
+++ b/src/main/java/mods/eln/misc/LiveDataManager.java
@@ -7,6 +7,8 @@ import cpw.mods.fml.common.gameevent.TickEvent.RenderTickEvent;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 public class LiveDataManager {
@@ -46,12 +48,12 @@ public class LiveDataManager {
 		return data;
 	}
 	
-	HashMap<Object,Element> map = new HashMap<Object, LiveDataManager.Element>();
+	Map<Object,Element> map = new HashMap<Object, LiveDataManager.Element>();
 	
 	@SubscribeEvent
 	public void tick(RenderTickEvent event) {
 		if(event.phase != Phase.START) return;
-		ArrayList<Object> keyToRemove = new ArrayList<Object>();
+		List<Object> keyToRemove = new ArrayList<Object>();
 		for(Entry<Object, Element> entry : map.entrySet()){
 			Element e = entry.getValue();
 			e.timeout--;

--- a/src/main/java/mods/eln/misc/Obj3DFolder.java
+++ b/src/main/java/mods/eln/misc/Obj3DFolder.java
@@ -10,6 +10,7 @@ import java.net.URLDecoder;
 import java.security.CodeSource;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
@@ -18,7 +19,7 @@ import java.util.jar.JarFile;
  */
 public class Obj3DFolder {
 
-    private HashMap<String, Obj3D> nameToObjHash = new HashMap<String, Obj3D>();
+    private Map<String, Obj3D> nameToObjHash = new HashMap<String, Obj3D>();
 
     /** Load all obj models available in the release mod asset folder. */
     public void loadAllElnModels() {

--- a/src/main/java/mods/eln/misc/Utils.java
+++ b/src/main/java/mods/eln/misc/Utils.java
@@ -863,7 +863,7 @@ public class Utils {
 
 	static public void getItemStack(String name, List list) {
 		Iterator aitem = Item.itemRegistry.iterator();
-		ArrayList<ItemStack> tempList = new ArrayList<ItemStack>(3000);
+		List<ItemStack> tempList = new ArrayList<ItemStack>(3000);
 		Item item;
 
 		while (aitem.hasNext()) {
@@ -1249,7 +1249,7 @@ public class Utils {
 		return new ItemStack(i, size, damage);
 	}
 
-	public static ArrayList<NBTTagCompound> getTags(NBTTagCompound nbt) {
+	public static List<NBTTagCompound> getTags(NBTTagCompound nbt) {
 		Object[] set = nbt.func_150296_c().toArray();
 
 		ArrayList<NBTTagCompound> tags = new ArrayList<NBTTagCompound>();

--- a/src/main/java/mods/eln/node/NodeManager.java
+++ b/src/main/java/mods/eln/node/NodeManager.java
@@ -138,7 +138,7 @@ public class NodeManager extends WorldSavedData {
 
 
 	public void loadFromNbt(NBTTagCompound nbt) {
-		ArrayList<NodeBase> addedNode = new ArrayList<NodeBase>();
+		List<NodeBase> addedNode = new ArrayList<NodeBase>();
 		for (Object o : Utils.getTags(nbt))
 		{
 			NBTTagCompound tag = (NBTTagCompound) o;
@@ -161,7 +161,7 @@ public class NodeManager extends WorldSavedData {
 
 	public void saveToNbt(NBTTagCompound nbt, int dim) {
 		int nodeCounter = 0;
-		ArrayList<NodeBase> nodesCopy = new ArrayList<NodeBase>();
+		List<NodeBase> nodesCopy = new ArrayList<NodeBase>();
 		nodesCopy.addAll(nodes);
 		for (NodeBase node : nodesCopy)
 		{

--- a/src/main/java/mods/eln/server/DelayedBlockRemove.java
+++ b/src/main/java/mods/eln/server/DelayedBlockRemove.java
@@ -6,12 +6,13 @@ import mods.eln.server.DelayedTaskManager.ITask;
 import net.minecraft.init.Blocks;
 
 import java.util.HashSet;
+import java.util.Set;
 
 public class DelayedBlockRemove implements ITask {
 
     Coordonate c;
 
-	private static HashSet<Coordonate> blocks = new HashSet<Coordonate>(); 
+	private static Set<Coordonate> blocks = new HashSet<Coordonate>(); 
 	
 	private DelayedBlockRemove(Coordonate c) {
 		this.c = c;

--- a/src/main/java/mods/eln/server/DelayedTaskManager.java
+++ b/src/main/java/mods/eln/server/DelayedTaskManager.java
@@ -8,6 +8,7 @@ import net.minecraftforge.common.MinecraftForge;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
+import java.util.List;
 
 public class DelayedTaskManager {
 
@@ -25,7 +26,7 @@ public class DelayedTaskManager {
 	@SubscribeEvent
 	public void tick(ServerTickEvent event) {
 		if (event.phase != Phase.END) return;
-		ArrayList<ITask> cpy = new ArrayList<DelayedTaskManager.ITask>(tasks);
+		List<ITask> cpy = new ArrayList<DelayedTaskManager.ITask>(tasks);
 		tasks.clear();
 		for (ITask t : cpy) {
 			t.run();

--- a/src/main/java/mods/eln/server/PlayerManager.java
+++ b/src/main/java/mods/eln/server/PlayerManager.java
@@ -9,11 +9,12 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 
 import java.util.Hashtable;
+import java.util.Map;
 import java.util.Map.Entry;
 
 public class PlayerManager {
 
-	private Hashtable<EntityPlayerMP, PlayerMetadata> metadataHash = new Hashtable<EntityPlayerMP, PlayerMetadata>();
+	private Map<EntityPlayerMP, PlayerMetadata> metadataHash = new Hashtable<EntityPlayerMP, PlayerMetadata>();
 
     public PlayerManager() {
         FMLCommonHandler.instance().bus().register(this);

--- a/src/main/java/mods/eln/sim/Simulator.java
+++ b/src/main/java/mods/eln/sim/Simulator.java
@@ -13,20 +13,22 @@ import mods.eln.sim.process.destruct.IDestructable;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public class Simulator /* ,IPacketHandler */{
 
 	public RootSystem mna;
 
 	private ArrayList<IProcess> slowProcessList;
-	private ArrayList<IProcess> slowPreProcessList;
+	private List<IProcess> slowPreProcessList;
 
 	private ArrayList<IProcess> electricalProcessList;
 
 	private ArrayList<IProcess> thermalFastProcessList, thermalSlowProcessList;
 	private ArrayList<ThermalConnection> thermalFastConnectionList, thermalSlowConnectionList;
 	private ArrayList<ThermalLoad> thermalFastLoadList, thermalSlowLoadList;
-	private HashSet<IDestructable> destructableSet;
+	private Set<IDestructable> destructableSet;
 
 	boolean run;
 
@@ -246,7 +248,7 @@ public class Simulator /* ,IPacketHandler */{
 		if (process != null) thermalSlowProcessList.remove(process);
 	}
 
-	public void addAllElectricalConnection(ArrayList<ElectricalConnection> connection) {
+	public void addAllElectricalConnection(Iterable<ElectricalConnection> connection) {
 		if (connection != null) {
 			for (ElectricalConnection c : connection) {
 				addElectricalComponent(c);
@@ -254,7 +256,7 @@ public class Simulator /* ,IPacketHandler */{
 		}
 	}
 
-	public void removeAllElectricalConnection(ArrayList<ElectricalConnection> connection) {
+	public void removeAllElectricalConnection(Iterable<ElectricalConnection> connection) {
 		if (connection != null) {
 			for (ElectricalConnection c : connection) {
 				removeElectricalComponent(c);
@@ -262,7 +264,7 @@ public class Simulator /* ,IPacketHandler */{
 		}
 	}
 
-	public void addAllElectricalComponent(ArrayList<Component> cList) {
+	public void addAllElectricalComponent(Iterable<Component> cList) {
 		if (cList != null) {
 			for (Component c : cList) {
 				addElectricalComponent(c);
@@ -270,7 +272,7 @@ public class Simulator /* ,IPacketHandler */{
 		}
 	}
 
-	public void removeAllElectricalComponent(ArrayList<Component> cList) {
+	public void removeAllElectricalComponent(Iterable<Component> cList) {
 		if (cList != null) {
 			for (Component c : cList) {
 				removeElectricalComponent(c);
@@ -278,7 +280,7 @@ public class Simulator /* ,IPacketHandler */{
 		}
 	}
 
-	public void addAllThermalConnection(ArrayList<ThermalConnection> connection) {
+	public void addAllThermalConnection(Iterable<ThermalConnection> connection) {
 		if (connection != null) {
 			for (ThermalConnection c : connection) {
 				addThermalConnection(c);
@@ -286,7 +288,7 @@ public class Simulator /* ,IPacketHandler */{
 		}
 	}
 
-	public void removeAllThermalConnection(ArrayList<ThermalConnection> connection) {
+	public void removeAllThermalConnection(Iterable<ThermalConnection> connection) {
 		if (connection != null) {
 			for (ThermalConnection c : connection) {
 				removeThermalConnection(c);
@@ -294,7 +296,7 @@ public class Simulator /* ,IPacketHandler */{
 		}
 	}
 
-	public void addAllElectricalLoad(ArrayList<ElectricalLoad> load) {
+	public void addAllElectricalLoad(Iterable<ElectricalLoad> load) {
 		if (load != null) {
 			for (ElectricalLoad l : load) {
 				addElectricalLoad(l);
@@ -302,7 +304,7 @@ public class Simulator /* ,IPacketHandler */{
 		}
 	}
 
-	public void removeAllElectricalLoad(ArrayList<ElectricalLoad> load) {
+	public void removeAllElectricalLoad(Iterable<ElectricalLoad> load) {
 		if (load != null) {
 			for (ElectricalLoad l : load) {
 				removeElectricalLoad(l);
@@ -310,7 +312,7 @@ public class Simulator /* ,IPacketHandler */{
 		}
 	}
 
-	public void addAllThermalLoad(ArrayList<ThermalLoad> load) {
+	public void addAllThermalLoad(Iterable<ThermalLoad> load) {
 		if (load != null) {
 			for (ThermalLoad c : load) {
 				addThermalLoad(c);
@@ -318,7 +320,7 @@ public class Simulator /* ,IPacketHandler */{
 		}
 	}
 
-	public void removeAllThermalLoad(ArrayList<ThermalLoad> load) {
+	public void removeAllThermalLoad(Iterable<ThermalLoad> load) {
 		if (load != null) {
 			for (ThermalLoad c : load) {
 				removeThermalLoad(c);
@@ -493,7 +495,7 @@ public class Simulator /* ,IPacketHandler */{
 		return mna.isRegistred(load);
 	}
 
-	void thermalStep(double dt, ArrayList<ThermalConnection> connectionList, ArrayList<IProcess> processList, ArrayList<ThermalLoad> loadList) {
+	void thermalStep(double dt, Iterable<ThermalConnection> connectionList, Iterable<IProcess> processList, Iterable<ThermalLoad> loadList) {
 		for (ThermalConnection c : connectionList) {
 			double i;
 			i = (c.L2.Tc - c.L1.Tc) / ((c.L2.Rs + c.L1.Rs));

--- a/src/main/java/mods/eln/sim/mna/RootSystem.java
+++ b/src/main/java/mods/eln/sim/mna/RootSystem.java
@@ -20,7 +20,7 @@ public class RootSystem {
 
 	//public HashMap<Component, IDestructor> componentDestructor = new HashMap<Component, IDestructor>();
 
-	public HashSet<Component> addComponents = new HashSet<Component>();
+	public Set<Component> addComponents = new HashSet<Component>();
 	public HashSet<State> addStates = new HashSet<State>();
 
 	static final int maxSubSystemSize = 100;
@@ -99,7 +99,7 @@ public class RootSystem {
 
 	private boolean isValidForLine(State s) {
 		if (!s.canBeSimplifiedByLine()) return false;
-		ArrayList<Component> sc = s.getConnectedComponentsNotAbstracted();
+		List<Component> sc = s.getConnectedComponentsNotAbstracted();
 		if (sc.size() != 2) return false;
 		for (Component c : sc) {
 			if (false == c instanceof Resistor) { return false; }
@@ -112,7 +112,7 @@ public class RootSystem {
 	}
 
 	private void generateLine() {
-		HashSet<State> stateScope = new HashSet<State>();
+		Set<State> stateScope = new HashSet<State>();
 		//HashSet<Resistor> resistorScope = new HashSet<Resistor>();
 		for (State s : addStates) {
 			if (isValidForLine(s)) {

--- a/src/main/java/mods/eln/sim/mna/SubSystem.java
+++ b/src/main/java/mods/eln/sim/mna/SubSystem.java
@@ -17,10 +17,11 @@ import org.apache.commons.math3.linear.RealMatrix;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
+import java.util.List;
 
 public class SubSystem {
 	public ArrayList<Component> component = new ArrayList<Component>();
-	public ArrayList<State> states = new ArrayList<State>();
+	public List<State> states = new ArrayList<State>();
 	public LinkedList<IDestructor> breakDestructor = new LinkedList<IDestructor>();
 	public ArrayList<SubSystem> interSystemConnectivity = new ArrayList<SubSystem>();
 	ArrayList<ISubSystemProcessI> processI = new ArrayList<ISubSystemProcessI>();

--- a/src/main/java/mods/eln/sixnode/electricalentitysensor/ElectricalEntitySensorSlowProcess.java
+++ b/src/main/java/mods/eln/sixnode/electricalentitysensor/ElectricalEntitySensorSlowProcess.java
@@ -72,7 +72,7 @@ public class ElectricalEntitySensorSlowProcess implements IProcess, INBTTReady {
 				Vec3 lastPos;
 				if ((lastPos = lastEPos.get(e)) != null) {
 					double weight = 0.4;
-					ArrayList<Block> blockList = Utils.traceRay(world, coord.x + 0.5, coord.y + 0.5, coord.z + 0.5, e.posX, e.posY + e.getEyeHeight(), e.posZ);
+					List<Block> blockList = Utils.traceRay(world, coord.x + 0.5, coord.y + 0.5, coord.z + 0.5, e.posX, e.posY + e.getEyeHeight(), e.posZ);
 					boolean view = true;
 
 					for (Block b : blockList) {

--- a/src/main/java/mods/eln/sixnode/electricalfiredetector/ElectricalFireDetectorSlowProcess.java
+++ b/src/main/java/mods/eln/sixnode/electricalfiredetector/ElectricalFireDetectorSlowProcess.java
@@ -8,6 +8,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockFire;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class ElectricalFireDetectorSlowProcess implements IProcess {
 
@@ -68,7 +69,7 @@ public class ElectricalFireDetectorSlowProcess implements IProcess {
                             fireDetected = true;
 
                             Coordonate coord = element.getCoordonate();
-                            ArrayList<Block> blockList = Utils.traceRay(coord.world(), coord.x + 0.5, coord.y + 0.5, coord.z + 0.5,
+                            List<Block> blockList = Utils.traceRay(coord.world(), coord.x + 0.5, coord.y + 0.5, coord.z + 0.5,
                                     detectionBBCenter.x + dx + 0.5, detectionBBCenter.y + dy + 0.5, detectionBBCenter.z + dz + 0.5);
 
                             for (Block b : blockList)

--- a/src/main/java/mods/eln/sixnode/lampsocket/LampSocketProcess.java
+++ b/src/main/java/mods/eln/sixnode/lampsocket/LampSocketProcess.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 import mods.eln.Eln;
 import mods.eln.generic.GenericItemUsingDamage;
@@ -102,7 +103,7 @@ public class LampSocketProcess implements IProcess, INBTTReady /*,LightBlockObse
 			Coordonate myCoord = lamp.sixNode.coordonate;
             LampSupplyElement.PowerSupplyChannelHandle best = null;
 			float bestDistance = 10000;
-			ArrayList<LampSupplyElement.PowerSupplyChannelHandle> list = LampSupplyElement.channelMap.get(lamp.channel);
+			List<LampSupplyElement.PowerSupplyChannelHandle> list = LampSupplyElement.channelMap.get(lamp.channel);
 			if (list != null) {
 				for (LampSupplyElement.PowerSupplyChannelHandle s : list) {
 					float distance = (float) s.element.sixNode.coordonate.trueDistanceTo(myCoord);

--- a/src/main/java/mods/eln/sixnode/lampsupply/LampSupplyElement.java
+++ b/src/main/java/mods/eln/sixnode/lampsupply/LampSupplyElement.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 
 public class LampSupplyElement extends SixNodeElement {
 
@@ -175,7 +176,7 @@ public class LampSupplyElement extends SixNodeElement {
 
 	static void channelRemove(LampSupplyElement tx,int id,String channel) {
         if(channel.equals("")) return;
-		ArrayList<PowerSupplyChannelHandle> list = channelMap.get(channel);
+		List<PowerSupplyChannelHandle> list = channelMap.get(channel);
 		if (list == null) return;
         Iterator<PowerSupplyChannelHandle> i = list.iterator();
         while (i.hasNext()) {

--- a/src/main/java/mods/eln/sixnode/modbusrtu/ModbusRtuGui.java
+++ b/src/main/java/mods/eln/sixnode/modbusrtu/ModbusRtuGui.java
@@ -10,6 +10,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 import static mods.eln.i18n.I18N.tr;
 
@@ -89,7 +90,7 @@ public class ModbusRtuGui extends GuiScreenEln {
 			y += 20;
 		}
 
-		ArrayList<WirelessTxStatus> tempListTx = new ArrayList<WirelessTxStatus>(render.wirelessTxStatusList.values());
+		List<WirelessTxStatus> tempListTx = new ArrayList<WirelessTxStatus>(render.wirelessTxStatusList.values());
 
 		while (tempListTx.size() != 0) {
 			int smaller = Integer.MAX_VALUE;
@@ -143,7 +144,7 @@ public class ModbusRtuGui extends GuiScreenEln {
 			y += 20;
 		}
 		
-		ArrayList<WirelessRxStatus> tempListRx = new ArrayList<WirelessRxStatus>(render.wirelessRxStatusList.values());
+		List<WirelessRxStatus> tempListRx = new ArrayList<WirelessRxStatus>(render.wirelessRxStatusList.values());
 
         while (tempListRx.size() != 0) {
 			int smaller = Integer.MAX_VALUE;

--- a/src/main/java/mods/eln/sixnode/powersocket/PowerSocketElement.java
+++ b/src/main/java/mods/eln/sixnode/powersocket/PowerSocketElement.java
@@ -28,6 +28,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 //TODO Copy-pasted from LampSupply. PowerSocket behavior must be implemented.
 public class PowerSocketElement extends SixNodeElement {
@@ -97,7 +98,7 @@ public class PowerSocketElement extends SixNodeElement {
 
 	static void channelRemove(PowerSocketElement tx) {
 		String channel = tx.channel;
-		ArrayList<PowerSocketElement> list = channelMap.get(channel);
+		List<PowerSocketElement> list = channelMap.get(channel);
 		if (list == null) return;
 		list.remove(tx);
 		if (list.size() == 0)

--- a/src/main/java/mods/eln/sixnode/wirelesssignal/WirelessUtils.java
+++ b/src/main/java/mods/eln/sixnode/wirelesssignal/WirelessUtils.java
@@ -9,6 +9,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 public class WirelessUtils {
@@ -26,7 +28,7 @@ public class WirelessUtils {
 		spotSet.add(from);
 		
 		if (!isRoot) {
-			for (ArrayList<IWirelessSignalTx> txs : from.getTx().values()) {
+			for (List<IWirelessSignalTx> txs : from.getTx().values()) {
 				for (IWirelessSignalTx tx : txs) {
 					if (isRoot)
 						strength = tx.getRange() - getVirtualDistance(tx.getCoordonate(), from.getCoordonate(), tx.getCoordonate().trueDistanceTo(from.getCoordonate()));
@@ -85,7 +87,7 @@ public class WirelessUtils {
 		}
 	}
 
-	private static void addTo(IWirelessSignalTx tx, double strength, HashMap<String, HashSet<IWirelessSignalTx>> reg, HashMap<IWirelessSignalTx, Double> txStrength) {
+	private static void addTo(IWirelessSignalTx tx, double strength, Map<String, HashSet<IWirelessSignalTx>> reg, Map<IWirelessSignalTx, Double> txStrength) {
 		String channel = tx.getChannel();
 		HashSet<IWirelessSignalTx> ch = reg.get(channel);
 		if (ch != null && ch.contains(tx)) return;
@@ -117,7 +119,7 @@ public class WirelessUtils {
 		if (channel != null) {
 			ArrayList<IWirelessSignalTx> inRangeTx = new ArrayList<IWirelessSignalTx>();
 			
-			ArrayList<IWirelessSignalTx> sameChannelTx = WirelessSignalTxElement.channelMap.get(channel);
+			List<IWirelessSignalTx> sameChannelTx = WirelessSignalTxElement.channelMap.get(channel);
 			if (sameChannelTx != null) {
 				for (IWirelessSignalTx tx : sameChannelTx) {
 					if (isInRange(tx.getCoordonate(), c, tx.getRange())) {

--- a/src/main/java/mods/eln/transparentnode/autominer/AutoMinerSlowProcess.java
+++ b/src/main/java/mods/eln/transparentnode/autominer/AutoMinerSlowProcess.java
@@ -1,6 +1,7 @@
 package mods.eln.transparentnode.autominer;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import mods.eln.Eln;
 import mods.eln.item.ElectricalDrillDescriptor;
@@ -115,7 +116,7 @@ public class AutoMinerSlowProcess implements IProcess, INBTTReady {
                         //
                         Block block = jobCoord.world().getBlock(jobCoord.x, jobCoord.y, jobCoord.z);
                         int meta = jobCoord.world().getBlockMetadata(jobCoord.x, jobCoord.y, jobCoord.z);
-                        ArrayList<ItemStack> drop = block.getDrops(jobCoord.world(), jobCoord.x, jobCoord.y, jobCoord.z, meta, 0);
+                        List<ItemStack> drop = block.getDrops(jobCoord.world(), jobCoord.x, jobCoord.y, jobCoord.z, meta, 0);
 
                         for (ItemStack stack : drop) {
                             drop(stack);

--- a/src/main/java/mods/eln/transparentnode/turret/TurretSlowProcess.java
+++ b/src/main/java/mods/eln/transparentnode/turret/TurretSlowProcess.java
@@ -172,7 +172,7 @@ public class TurretSlowProcess extends StateMachine {
                         if (filterClass == null || !filterClass.isAssignableFrom(entity.getClass())) return null;
                     }
 
-					ArrayList<Block> blockList = Utils.traceRay(coord.world(), coord.x + 0.5, coord.y + 0.5, coord.z + 0.5, 
+					List<Block> blockList = Utils.traceRay(coord.world(), coord.x + 0.5, coord.y + 0.5, coord.z + 0.5, 
 																entity.posX, entity.posY + entity.getEyeHeight(), entity.posZ);
 					boolean visible = true;
 					for (Block b: blockList)
@@ -269,7 +269,7 @@ public class TurretSlowProcess extends StateMachine {
 					Math.abs(target.posZ - coord.z) > element.getDescriptor().getProperties().aimDistance )
 				return new SeekingState();
 			
-			ArrayList<Block> blockList = Utils.traceRay(coord.world(), coord.x + 0.5, coord.y + 0.5, coord.z + 0.5, 
+			List<Block> blockList = Utils.traceRay(coord.world(), coord.x + 0.5, coord.y + 0.5, coord.z + 0.5, 
 					target.posX, target.posY + target.getEyeHeight(), target.posZ);
 			for (Block b: blockList)
 				if (b.isOpaqueCube()) 

--- a/src/main/java/mods/eln/wiki/ItemDefault.java
+++ b/src/main/java/mods/eln/wiki/ItemDefault.java
@@ -55,8 +55,8 @@ public class ItemDefault extends Default {
 
 			if(plugIn != null) y = plugIn.top(y, extender, stack);
 
-			ArrayList<IRecipe> recipeOutList = new ArrayList<IRecipe>();
-			ArrayList<IRecipe> recipeInList = new ArrayList<IRecipe>();
+			List<IRecipe> recipeOutList = new ArrayList<IRecipe>();
+			List<IRecipe> recipeInList = new ArrayList<IRecipe>();
 			if(stack != null) {
 				List list = CraftingManager.getInstance().getRecipeList();
 				for(Object o : list) {
@@ -147,7 +147,7 @@ public class ItemDefault extends Default {
 
 			{
 				counter = -1;
-				ArrayList<Recipe> list = RecipesList.getGlobalRecipeWithInput(stack);
+				List<Recipe> list = RecipesList.getGlobalRecipeWithInput(stack);
 				if(list.size() == 0) {
 					//extender.add(new GuiLabel(6, y, "Can't Product"));
 				}
@@ -178,7 +178,7 @@ public class ItemDefault extends Default {
 			}
 			{
 				counter = -1;
-				ArrayList<Recipe> list = RecipesList.getGlobalRecipeWithOutput(stack);
+				List<Recipe> list = RecipesList.getGlobalRecipeWithOutput(stack);
 				if(list.size() == 0) {
 					//extender.add(new GuiLabel(6, y, "Can't Product"));
 				}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1319 - “Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList" ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319
Please let me know if you have any questions.
Ayman Abdelghany.
