### PR TITLE
Feature/sixnode placing direction support

### DIFF
--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -2348,7 +2348,7 @@ public class Eln {
 			name = TR_NAME(Type.NONE, "High Voltage Relay");
 
 			desc = new ElectricalRelayDescriptor(
-					name, obj.getObj("relay800"),
+					name, obj.getObj("relayBig"),
 					highVoltageCableDescriptor);
 
 			sixNodeItem.addDescriptor(subId + (id << 6), desc);
@@ -2359,7 +2359,7 @@ public class Eln {
 			name = TR_NAME(Type.NONE, "Very High Voltage Relay");
 
 			desc = new ElectricalRelayDescriptor(
-					name, obj.getObj("relay800"),
+					name, obj.getObj("relayBig"),
 					veryHighVoltageCableDescriptor);
 
 			sixNodeItem.addDescriptor(subId + (id << 6), desc);

--- a/src/main/java/mods/eln/misc/LRDU.java
+++ b/src/main/java/mods/eln/misc/LRDU.java
@@ -1,13 +1,12 @@
 package mods.eln.misc;
 
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.Vec3;
+import org.lwjgl.opengl.GL11;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.Vec3;
-
-import org.lwjgl.opengl.GL11;
 
 /**
  * Represents the 6 possible directions along the axis of a block.
@@ -105,6 +104,24 @@ public enum LRDU {
 		}
 	}
 
+	public float[] rotate4PinDistances(float [] distances) {
+		if (distances.length != 4 ) return distances;
+		switch (this) {
+			case Left:
+				return new float[] {distances[3], distances[2], distances[0], distances[1]};
+
+			case Down:
+				return new float[] {distances[1], distances[0], distances[3], distances[2]};
+
+			case Right:
+				return new float[] {distances[2], distances[3], distances[1], distances[0]};
+
+			case Up:
+			default:
+				return distances;
+		}
+	}
+
 	public LRDU getNextClockwise() {
 		switch (this) {
 			case Down: return Left;
@@ -199,7 +216,7 @@ public enum LRDU {
 			e.printStackTrace();
 		}
 	}
-	
+
 	static public LRDU deserialize(DataInputStream stream) {
 		try {
 			return fromInt(stream.readByte());

--- a/src/main/java/mods/eln/node/six/SixNode.java
+++ b/src/main/java/mods/eln/node/six/SixNode.java
@@ -1,11 +1,5 @@
 package mods.eln.node.six;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-
 import mods.eln.Eln;
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
@@ -27,6 +21,12 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.chunk.Chunk;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
 
 public class SixNode extends Node {
 
@@ -86,7 +86,7 @@ public class SixNode extends Node {
 		lrduElementMask.clear();
 	}
 
-	public boolean createSubBlock(ItemStack itemStack, Direction direction) {
+	public boolean createSubBlock(ItemStack itemStack, Direction direction, EntityPlayer player) {
 		
 		SixNodeDescriptor descriptor = Eln.sixNodeItem.getDescriptor(itemStack);
 		if (sideElementList[direction.getInt()] != null)
@@ -99,6 +99,7 @@ public class SixNode extends Node {
 			sideElementIdList[direction.getInt()] = 0;
 
 			disconnect();
+			sideElementList[direction.getInt()].front = descriptor.getFrontFromPlace(direction, player);
 			sideElementList[direction.getInt()].initialize();
 			sideElementIdList[direction.getInt()] = itemStack.getItemDamage();
 

--- a/src/main/java/mods/eln/node/six/SixNodeDescriptor.java
+++ b/src/main/java/mods/eln/node/six/SixNodeDescriptor.java
@@ -119,4 +119,8 @@ public class SixNodeDescriptor extends GenericItemBlockUsingDamageDescriptor imp
             return tr("Not enough space for this block");
         return null;
     }
+
+    public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+        return LRDU.Up;
+    }
 }

--- a/src/main/java/mods/eln/node/six/SixNodeDescriptor.java
+++ b/src/main/java/mods/eln/node/six/SixNodeDescriptor.java
@@ -126,7 +126,7 @@ public class SixNodeDescriptor extends GenericItemBlockUsingDamageDescriptor imp
             case YP:
                 Direction viewDirection = Utils.entityLivingHorizontalViewDirection(player);
                 LRDU front = side.getLRDUGoingTo(viewDirection);
-                return front;
+                return side == Direction.YN ? front : front.inverse();
 
             default:
                 return LRDU.Up;

--- a/src/main/java/mods/eln/node/six/SixNodeDescriptor.java
+++ b/src/main/java/mods/eln/node/six/SixNodeDescriptor.java
@@ -121,6 +121,15 @@ public class SixNodeDescriptor extends GenericItemBlockUsingDamageDescriptor imp
     }
 
     public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
-        return LRDU.Up;
+        switch (side) {
+            case YN:
+            case YP:
+                Direction viewDirection = Utils.entityLivingHorizontalViewDirection(player);
+                LRDU front = side.getLRDUGoingTo(viewDirection);
+                return front;
+
+            default:
+                return LRDU.Up;
+        }
     }
 }

--- a/src/main/java/mods/eln/node/six/SixNodeItem.java
+++ b/src/main/java/mods/eln/node/six/SixNodeItem.java
@@ -132,7 +132,7 @@ public class SixNodeItem extends GenericItemBlockUsingDamage<SixNodeDescriptor> 
 
                 SixNode sixNode = new SixNode();
                 sixNode.onBlockPlacedBy(new Coordonate(x, y, z, world), direction, player, stack);
-                sixNode.createSubBlock(stack, direction);
+                sixNode.createSubBlock(stack, direction, player);
 
                 world.setBlock(x, y, z, block, metadata, 0x03);
                 block.getIfOtherBlockIsSolid(world, x, y, z, direction);
@@ -148,7 +148,7 @@ public class SixNodeItem extends GenericItemBlockUsingDamage<SixNodeDescriptor> 
                 return false;
             }
             if (sixNode.getSideEnable(direction) == false && block.getIfOtherBlockIsSolid(world, x, y, z, direction)) {
-                sixNode.createSubBlock(stack, direction);
+                sixNode.createSubBlock(stack, direction, player);
                 block.onBlockPlacedBy(world, x, y, z, Direction.fromIntMinecraftSide(side).getInverse(), player, metadata);
                 return true;
             }

--- a/src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerDescriptor.java
@@ -124,6 +124,6 @@ public class BatteryChargerDescriptor extends SixNodeDescriptor {
 
 	@Override
 	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
-		return LRDU.Down;
+		return super.getFrontFromPlace(side, player).inverse();
 	}
 }

--- a/src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerDescriptor.java
@@ -1,10 +1,7 @@
 package mods.eln.sixnode.batterycharger;
 
-import mods.eln.misc.Obj3D;
+import mods.eln.misc.*;
 import mods.eln.misc.Obj3D.Obj3DPart;
-import mods.eln.misc.Utils;
-import mods.eln.misc.UtilsClient;
-import mods.eln.misc.VoltageLevelColor;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.sim.mna.component.Resistor;
 import mods.eln.sim.nbt.NbtElectricalLoad;
@@ -123,5 +120,10 @@ public class BatteryChargerDescriptor extends SixNodeDescriptor {
 		Collections.addAll(list, tr("Can be used to recharge\nelectrical items like:\nFlash Light, X-Ray scanner\nand Portable Battery ...").split("\\\n"));
 		list.add(tr("Nominal power: %1$W", nominalPower));
 		//list.add(Utils.plotPower("Maximal power", nominalPower * 3));
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return LRDU.Down;
 	}
 }

--- a/src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerElement.java
+++ b/src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerElement.java
@@ -1,9 +1,5 @@
 package mods.eln.sixnode.batterycharger;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-
 import mods.eln.item.electricalinterface.IItemEnergyBattery;
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
@@ -26,6 +22,10 @@ import net.minecraft.inventory.Container;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 
 public class BatteryChargerElement extends SixNodeElement {
 
@@ -71,8 +71,6 @@ public class BatteryChargerElement extends SixNodeElement {
 		WorldExplosion exp = new WorldExplosion(this).machineExplosion();
 		slowProcessList.add(voltageWatchDog.set(powerLoad).setUNominal(this.descriptor.nominalVoltage).set(exp));
 		//slowProcessList.add(powerWatchDog.set(powerResistor).setPmax(this.descriptor.nominalPower * 3).set(exp));
-		
-		front = LRDU.Down;
 	}
 	
 	@Override

--- a/src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerRender.java
+++ b/src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerRender.java
@@ -44,13 +44,18 @@ public class BatteryChargerRender extends SixNodeElementRender {
 	public void draw() {	
 		super.draw();
 
+		drawPowerPin(descriptor.pinDistance);
+
+		if (side.isY()) {
+			front.glRotateOnX();
+			GL11.glRotatef(90f, 1, 0, 0);
+		}
+
 		drawEntityItem(b[0], 0.1875, 0.15625, 0.15625, alpha, 0.2f);
 		drawEntityItem(b[1], 0.1875, 0.15625, -0.15625, alpha, 0.2f);
 		drawEntityItem(b[2], 0.1875, -0.15625, 0.15625, alpha, 0.2f);
 		drawEntityItem(b[3], 0.1875, -0.15625, -0.15625, alpha, 0.2f);
 
-		drawPowerPin(descriptor.pinDistance);
-		
 		descriptor.draw(batteryPresence, charged);
 	}
 

--- a/src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerRender.java
+++ b/src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerRender.java
@@ -47,8 +47,7 @@ public class BatteryChargerRender extends SixNodeElementRender {
 		drawPowerPin(descriptor.pinDistance);
 
 		if (side.isY()) {
-			front.glRotateOnX();
-			GL11.glRotatef(90f, 1, 0, 0);
+			front.right().glRotateOnX();
 		}
 
 		drawEntityItem(b[0], 0.1875, 0.15625, 0.15625, alpha, 0.2f);

--- a/src/main/java/mods/eln/sixnode/diode/DiodeElement.java
+++ b/src/main/java/mods/eln/sixnode/diode/DiodeElement.java
@@ -1,8 +1,5 @@
 package mods.eln.sixnode.diode;
 
-import java.io.DataOutputStream;
-import java.io.IOException;
-
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
 import mods.eln.misc.Utils;
@@ -19,12 +16,13 @@ import mods.eln.sim.nbt.NbtThermalLoad;
 import mods.eln.sim.process.destruct.ThermalLoadWatchDog;
 import mods.eln.sim.process.destruct.WorldExplosion;
 import mods.eln.sim.process.heater.DiodeHeatThermalLoad;
-import mods.eln.sim.process.heater.ResistorHeatThermalLoad;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
 
 public class DiodeElement extends SixNodeElement {
 
@@ -37,15 +35,12 @@ public class DiodeElement extends SixNodeElement {
     public ThermalLoadWatchDog thermalWatchdog = new ThermalLoadWatchDog();
     public DiodeProcess diodeProcess = new DiodeProcess(resistorSwitch);
 
-    LRDU front;
-
     public DiodeElement(SixNode sixNode, Direction side, SixNodeDescriptor descriptor) {
 		super(sixNode, side, descriptor);
 
 		this.descriptor = (DiodeDescriptor) descriptor;
 		thermalLoad.setAsSlow();
 		
-		front = LRDU.Left;
 		electricalLoadList.add(anodeLoad);
 		electricalLoadList.add(catodeLoad);
 		thermalLoadList.add(thermalLoad);

--- a/src/main/java/mods/eln/sixnode/electricalalarm/ElectricalAlarmDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricalalarm/ElectricalAlarmDescriptor.java
@@ -112,4 +112,9 @@ public class ElectricalAlarmDescriptor extends SixNodeDescriptor {
         Collections.addAll(list, tr("Emits an acoustic alarm if\nthe input signal is high").split("\n"));
         list.add(tr(""));
     }
+
+    @Override
+    public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+        return super.getFrontFromPlace(side, player).inverse();
+    }
 }

--- a/src/main/java/mods/eln/sixnode/electricalalarm/ElectricalAlarmElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalalarm/ElectricalAlarmElement.java
@@ -1,9 +1,5 @@
 package mods.eln.sixnode.electricalalarm;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
 import mods.eln.misc.Utils;
@@ -18,13 +14,16 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
 public class ElectricalAlarmElement extends SixNodeElement {
 
 	ElectricalAlarmDescriptor descriptor;
 
     public NbtElectricalGateInput inputGate = new NbtElectricalGateInput("inputGate");
     public ElectricalAlarmSlowProcess slowProcess = new ElectricalAlarmSlowProcess(this);
-    LRDU front;
 
     boolean warm = false;
 
@@ -34,8 +33,7 @@ public class ElectricalAlarmElement extends SixNodeElement {
 
     public ElectricalAlarmElement(SixNode sixNode, Direction side, SixNodeDescriptor descriptor) {
 		super(sixNode, side, descriptor);
-		front = LRDU.Down;
-    	electricalLoadList.add(inputGate);
+		electricalLoadList.add(inputGate);
     	slowProcessList.add(slowProcess);
     	this.descriptor = (ElectricalAlarmDescriptor) descriptor;
 	}

--- a/src/main/java/mods/eln/sixnode/electricalalarm/ElectricalAlarmRender.java
+++ b/src/main/java/mods/eln/sixnode/electricalalarm/ElectricalAlarmRender.java
@@ -1,8 +1,5 @@
 package mods.eln.sixnode.electricalalarm;
 
-import java.io.DataInputStream;
-import java.io.IOException;
-
 import mods.eln.Eln;
 import mods.eln.cable.CableRenderDescriptor;
 import mods.eln.misc.Direction;
@@ -14,6 +11,10 @@ import mods.eln.node.six.SixNodeElementRender;
 import mods.eln.node.six.SixNodeEntity;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayer;
+import org.lwjgl.opengl.GL11;
+
+import java.io.DataInputStream;
+import java.io.IOException;
 
 public class ElectricalAlarmRender extends SixNodeElementRender {
 
@@ -36,9 +37,14 @@ public class ElectricalAlarmRender extends SixNodeElementRender {
 	public void draw() {
 		super.draw();
 		
-		drawSignalPin(front,descriptor.pinDistance);
 
-		//front.glRotateOnX();		
+		if (side.isY()) {
+			front.glRotateOnX();
+			GL11.glRotatef(90, 1, 0, 0);
+			drawSignalPin(LRDU.Down, descriptor.pinDistance);
+		} else {
+			drawSignalPin(front, descriptor.pinDistance);
+		}
 		descriptor.draw(warm, rotAlpha);
 	}
 

--- a/src/main/java/mods/eln/sixnode/electricalalarm/ElectricalAlarmRender.java
+++ b/src/main/java/mods/eln/sixnode/electricalalarm/ElectricalAlarmRender.java
@@ -11,7 +11,6 @@ import mods.eln.node.six.SixNodeElementRender;
 import mods.eln.node.six.SixNodeEntity;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayer;
-import org.lwjgl.opengl.GL11;
 
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -39,8 +38,7 @@ public class ElectricalAlarmRender extends SixNodeElementRender {
 		
 
 		if (side.isY()) {
-			front.glRotateOnX();
-			GL11.glRotatef(90, 1, 0, 0);
+			front.right().glRotateOnX();
 			drawSignalPin(LRDU.Down, descriptor.pinDistance);
 		} else {
 			drawSignalPin(front, descriptor.pinDistance);

--- a/src/main/java/mods/eln/sixnode/electricalbreaker/ElectricalBreakerDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricalbreaker/ElectricalBreakerDescriptor.java
@@ -1,5 +1,7 @@
 package mods.eln.sixnode.electricalbreaker;
 
+import mods.eln.misc.Direction;
+import mods.eln.misc.LRDU;
 import mods.eln.misc.Obj3D;
 import mods.eln.misc.Obj3D.Obj3DPart;
 import mods.eln.misc.VoltageLevelColor;
@@ -85,5 +87,10 @@ public class ElectricalBreakerDescriptor extends SixNodeDescriptor {
 	public void addInformation(ItemStack itemStack, EntityPlayer entityPlayer, List list, boolean par4) {
 		super.addInformation(itemStack, entityPlayer, list, par4);
 		Collections.addAll(list, (tr("Protects electrical components\nOpens contact if:\n  - Voltage exceeds a certain level\n- Current exceeds the cable limit").split("\n")));
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return LRDU.Down;
 	}
 }

--- a/src/main/java/mods/eln/sixnode/electricalbreaker/ElectricalBreakerDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricalbreaker/ElectricalBreakerDescriptor.java
@@ -91,6 +91,6 @@ public class ElectricalBreakerDescriptor extends SixNodeDescriptor {
 
 	@Override
 	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
-		return LRDU.Down;
+		return super.getFrontFromPlace(side, player).inverse();
 	}
 }

--- a/src/main/java/mods/eln/sixnode/electricalbreaker/ElectricalBreakerElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalbreaker/ElectricalBreakerElement.java
@@ -49,8 +49,7 @@ public class ElectricalBreakerElement extends SixNodeElement {
 	public ElectricalBreakerElement(SixNode sixNode, Direction side, SixNodeDescriptor descriptor) {
 		super(sixNode, side, descriptor);
 
-		front = LRDU.Down;
-    	electricalLoadList.add(aLoad);
+		electricalLoadList.add(aLoad);
     	electricalLoadList.add(bLoad);
     	electricalComponentList.add(switchResistor);
     	electricalComponentList.add(new Resistor(bLoad, null).pullDown());

--- a/src/main/java/mods/eln/sixnode/electricaldatalogger/ElectricalDataLoggerDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricaldatalogger/ElectricalDataLoggerDescriptor.java
@@ -62,7 +62,7 @@ public class ElectricalDataLoggerDescriptor extends SixNodeDescriptor {
 		}
 		
 		if (onFloor) {
-			//setPlaceDirection(Direction.YN);
+			setPlaceDirection(Direction.YN);
 		}
 
 		voltageLevelColor = VoltageLevelColor.SignalVoltage;
@@ -73,9 +73,9 @@ public class ElectricalDataLoggerDescriptor extends SixNodeDescriptor {
         return true;
     }
 
-	void draw(DataLogs log, LRDU front, int objPosMX, int objPosMZ) {
-		if (onFloor) front.glRotateOnX();
-        else GL11.glRotatef(90, 1, 0, 0);
+	void draw(DataLogs log, Direction side, LRDU front, int objPosMX, int objPosMZ) {
+		if (onFloor || side.isY()) front.glRotateOnX();
+        if (!onFloor) GL11.glRotatef(90, 1, 0, 0);
 		//GL11.glDisable(GL11.GL_TEXTURE_2D);
 		if (main != null) main.draw();
 		//GL11.glEnable(GL11.GL_TEXTURE_2D);
@@ -155,17 +155,15 @@ public class ElectricalDataLoggerDescriptor extends SixNodeDescriptor {
 
 	@Override
 	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
-		switch (side) {
-			case YN:
-			case YP:
-				return side.getLRDUGoingTo(Utils.entityLivingHorizontalViewDirection(player)).inverse();
-
-			default:
-				return super.getFrontFromPlace(side, player);
+		LRDU front = super.getFrontFromPlace(side, player);
+		if (onFloor) {
+			return front.inverse();
+		} else {
+			if (side.isY()) {
+				return front.left();
+			} else {
+				return front;
+			}
 		}
 	}
 }
-/*
- * 	        	GL11.glScalef(1f, -1f, 1f);
-	        	GL11.glTranslatef(0.1f, -0.5f, 0.5f);
-	        	GL11.glRotatef(90, 0f, 1f, 0f);  */

--- a/src/main/java/mods/eln/sixnode/electricaldatalogger/ElectricalDataLoggerDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricaldatalogger/ElectricalDataLoggerDescriptor.java
@@ -62,7 +62,7 @@ public class ElectricalDataLoggerDescriptor extends SixNodeDescriptor {
 		}
 		
 		if (onFloor) {
-			setPlaceDirection(Direction.YN);
+			//setPlaceDirection(Direction.YN);
 		}
 
 		voltageLevelColor = VoltageLevelColor.SignalVoltage;
@@ -151,6 +151,18 @@ public class ElectricalDataLoggerDescriptor extends SixNodeDescriptor {
 		super.addInformation(itemStack, entityPlayer, list, par4);
 		Collections.addAll(list, tr("Measures the voltage of an\nelectrical signal and plots\nthe data in real time.").split("\n"));
 		list.add(tr("It can store up to 256 points."));
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		switch (side) {
+			case YN:
+			case YP:
+				return side.getLRDUGoingTo(Utils.entityLivingHorizontalViewDirection(player)).inverse();
+
+			default:
+				return super.getFrontFromPlace(side, player);
+		}
 	}
 }
 /*

--- a/src/main/java/mods/eln/sixnode/electricaldatalogger/ElectricalDataLoggerRender.java
+++ b/src/main/java/mods/eln/sixnode/electricaldatalogger/ElectricalDataLoggerRender.java
@@ -44,8 +44,7 @@ public class ElectricalDataLoggerRender extends SixNodeElementRender {
         if (!descriptor.onFloor) {
 			if (side.isY()) {
 				GL11.glPushMatrix();
-				front.glRotateOnX();
-				GL11.glRotatef(90, 1, 0, 0);
+				front.right().glRotateOnX();
 				drawSignalPin(LRDU.Right, new float[]{0, 5.67f, 0, 0});
 				GL11.glPopMatrix();
 			} else {

--- a/src/main/java/mods/eln/sixnode/electricaldatalogger/ElectricalDataLoggerRender.java
+++ b/src/main/java/mods/eln/sixnode/electricaldatalogger/ElectricalDataLoggerRender.java
@@ -10,6 +10,7 @@ import mods.eln.node.six.SixNodeElementRender;
 import mods.eln.node.six.SixNodeEntity;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayer;
+import org.lwjgl.opengl.GL11;
 
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -41,9 +42,17 @@ public class ElectricalDataLoggerRender extends SixNodeElementRender {
 	public void draw() {
 		super.draw();
         if (!descriptor.onFloor) {
-            drawSignalPin(front.inverse(), new float[]{6.37f, 6.37f, 5.67f, 6.12f});
+			if (side.isY()) {
+				GL11.glPushMatrix();
+				front.glRotateOnX();
+				GL11.glRotatef(90, 1, 0, 0);
+				drawSignalPin(LRDU.Right, new float[]{0, 5.67f, 0, 0});
+				GL11.glPopMatrix();
+			} else {
+				drawSignalPin(front.inverse(), new float[]{6.37f, 6.37f, 5.67f, 6.12f});
+			}
         }
-        descriptor.draw(log, front, this.tileEntity.xCoord, this.tileEntity.zCoord);
+        descriptor.draw(log, side, front, this.tileEntity.xCoord, this.tileEntity.zCoord);
 	}
 
 	/*

--- a/src/main/java/mods/eln/sixnode/electricalentitysensor/ElectricalEntitySensorDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricalentitysensor/ElectricalEntitySensorDescriptor.java
@@ -1,11 +1,8 @@
 package mods.eln.sixnode.electricalentitysensor;
 
 import mods.eln.item.EntitySensorFilterDescriptor;
-import mods.eln.misc.Obj3D;
+import mods.eln.misc.*;
 import mods.eln.misc.Obj3D.Obj3DPart;
-import mods.eln.misc.Utils;
-import mods.eln.misc.UtilsClient;
-import mods.eln.misc.VoltageLevelColor;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.wiki.Data;
 import net.minecraft.entity.player.EntityPlayer;
@@ -94,5 +91,10 @@ public class ElectricalEntitySensorDescriptor extends SixNodeDescriptor {
 			GL11.glScalef(2f, 2f, 2f);
 			draw(false, null);
 		}
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return super.getFrontFromPlace(side, player).right();
 	}
 }

--- a/src/main/java/mods/eln/sixnode/electricalfiredetector/ElectricalFireDetectorDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricalfiredetector/ElectricalFireDetectorDescriptor.java
@@ -1,10 +1,7 @@
 package mods.eln.sixnode.electricalfiredetector;
 
-import mods.eln.misc.Obj3D;
+import mods.eln.misc.*;
 import mods.eln.misc.Obj3D.Obj3DPart;
-import mods.eln.misc.Utils;
-import mods.eln.misc.UtilsClient;
-import mods.eln.misc.VoltageLevelColor;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.wiki.Data;
 import net.minecraft.entity.player.EntityPlayer;
@@ -92,5 +89,10 @@ public class ElectricalFireDetectorDescriptor extends SixNodeDescriptor {
             GL11.glScalef(2f, 2f, 2f);
             draw(false);
         }
+    }
+
+    @Override
+    public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+        return super.getFrontFromPlace(side, player).right();
     }
 }

--- a/src/main/java/mods/eln/sixnode/electricalgatesource/ElectricalGateSourceDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricalgatesource/ElectricalGateSourceDescriptor.java
@@ -1,5 +1,7 @@
 package mods.eln.sixnode.electricalgatesource;
 
+import mods.eln.misc.Direction;
+import mods.eln.misc.LRDU;
 import mods.eln.misc.VoltageLevelColor;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.wiki.Data;
@@ -83,5 +85,10 @@ public class ElectricalGateSourceDescriptor extends SixNodeDescriptor {
 		} else {
 			super.renderItem(type, item, data);
 		}
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return super.getFrontFromPlace(side, player).inverse();
 	}
 }

--- a/src/main/java/mods/eln/sixnode/electricalgatesource/ElectricalGateSourceElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalgatesource/ElectricalGateSourceElement.java
@@ -31,15 +31,11 @@ public class ElectricalGateSourceElement extends SixNodeElement {
 
     public AutoResetProcess autoResetProcess;
 
-    LRDU front;
-
     public static final byte setVoltagerId = 1;
 
 	public ElectricalGateSourceElement(SixNode sixNode, Direction side, SixNodeDescriptor descriptor) {
 		super(sixNode, side, descriptor);
 		this.descriptor = (ElectricalGateSourceDescriptor) descriptor;
-
-		front = LRDU.Left;
 
 		electricalLoadList.add(outputGate);
 		electricalComponentList.add(outputGateProcess);

--- a/src/main/java/mods/eln/sixnode/electricalgatesource/ElectricalGateSourceRender.java
+++ b/src/main/java/mods/eln/sixnode/electricalgatesource/ElectricalGateSourceRender.java
@@ -38,7 +38,11 @@ public class ElectricalGateSourceRender extends SixNodeElementRender {
 		super.draw();
 		drawSignalPin(front, new float[] { 3, 3, 3, 3 });
 
-		LRDU.Down.glRotateOnX();
+		if (side.isY()) {
+			front.glRotateOnX();
+		} else {
+			LRDU.Down.glRotateOnX();
+		}
 		descriptor.draw(interpolator.get(), UtilsClient.distanceFromClientPlayer(this.tileEntity), tileEntity);
 	}
 

--- a/src/main/java/mods/eln/sixnode/electricallightsensor/ElectricalLightSensorDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricallightsensor/ElectricalLightSensorDescriptor.java
@@ -1,10 +1,8 @@
 package mods.eln.sixnode.electricallightsensor;
 
 import mods.eln.Eln;
-import mods.eln.misc.Obj3D;
+import mods.eln.misc.*;
 import mods.eln.misc.Obj3D.Obj3DPart;
-import mods.eln.misc.Utils;
-import mods.eln.misc.VoltageLevelColor;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.wiki.Data;
 import net.minecraft.entity.player.EntityPlayer;
@@ -87,5 +85,10 @@ public class ElectricalLightSensorDescriptor extends SixNodeDescriptor {
 			GL11.glScalef(2f, 2f, 2f);
 			draw();
 		}
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return super.getFrontFromPlace(side, player).right();
 	}
 }

--- a/src/main/java/mods/eln/sixnode/electricallightsensor/ElectricalLightSensorRender.java
+++ b/src/main/java/mods/eln/sixnode/electricallightsensor/ElectricalLightSensorRender.java
@@ -21,7 +21,11 @@ public class ElectricalLightSensorRender extends SixNodeElementRender {
 	public void draw() {
 		super.draw();
 		drawSignalPin(front.right(),descriptor.pinDistance);
-		
+
+		if (side.isY()) {
+			front.glRotateOnX();
+		}
+
 		descriptor.draw();
 	}
 

--- a/src/main/java/mods/eln/sixnode/electricalmath/ElectricalMathDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricalmath/ElectricalMathDescriptor.java
@@ -1,11 +1,8 @@
 package mods.eln.sixnode.electricalmath;
 
 import mods.eln.gui.GuiLabel;
-import mods.eln.misc.Obj3D;
+import mods.eln.misc.*;
 import mods.eln.misc.Obj3D.Obj3DPart;
-import mods.eln.misc.Utils;
-import mods.eln.misc.UtilsClient;
-import mods.eln.misc.VoltageLevelColor;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.wiki.Data;
 import mods.eln.wiki.GuiVerticalExtender;
@@ -155,5 +152,10 @@ public class ElectricalMathDescriptor extends SixNodeDescriptor implements IPlug
 	@Override
 	public int bottom(int y, GuiVerticalExtender extender, ItemStack stack) {
 		return y;
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return super.getFrontFromPlace(side, player);
 	}
 }

--- a/src/main/java/mods/eln/sixnode/electricalmath/ElectricalMathDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricalmath/ElectricalMathDescriptor.java
@@ -153,9 +153,4 @@ public class ElectricalMathDescriptor extends SixNodeDescriptor implements IPlug
 	public int bottom(int y, GuiVerticalExtender extender, ItemStack stack) {
 		return y;
 	}
-
-	@Override
-	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
-		return super.getFrontFromPlace(side, player);
-	}
 }

--- a/src/main/java/mods/eln/sixnode/electricalmath/ElectricalMathRender.java
+++ b/src/main/java/mods/eln/sixnode/electricalmath/ElectricalMathRender.java
@@ -1,24 +1,18 @@
 package mods.eln.sixnode.electricalmath;
 
-import java.io.DataInputStream;
-import java.io.IOException;
-
 import mods.eln.Eln;
 import mods.eln.cable.CableRenderDescriptor;
-import mods.eln.misc.Coordonate;
-import mods.eln.misc.Direction;
-import mods.eln.misc.LRDU;
-import mods.eln.misc.PhysicalInterpolator;
-import mods.eln.misc.Utils;
-import mods.eln.misc.UtilsClient;
+import mods.eln.misc.*;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.node.six.SixNodeElementInventory;
 import mods.eln.node.six.SixNodeElementRender;
 import mods.eln.node.six.SixNodeEntity;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayer;
-
 import org.lwjgl.opengl.GL11;
+
+import java.io.DataInputStream;
+import java.io.IOException;
 
 public class ElectricalMathRender extends SixNodeElementRender {
 
@@ -65,17 +59,28 @@ public class ElectricalMathRender extends SixNodeElementRender {
 	@Override
 	public void draw() {
 		super.draw();
-		
+
+		float[] pinDistances = null;
+		if (side.isY()) {
+			pinDistances = front.rotate4PinDistances(descriptor.pinDistance);
+		} else {
+			pinDistances = descriptor.pinDistance;
+		}
+
 		if (UtilsClient.distanceFromClientPlayer(tileEntity) < 15) {
 			GL11.glColor3f(0, 0, 0);
-			UtilsClient.drawConnectionPinSixNode(front, descriptor.pinDistance, 1.8f, 1.35f);
+			UtilsClient.drawConnectionPinSixNode(front, pinDistances, 1.8f, 1.35f);
 			GL11.glColor3f(1, 0, 0);
-			UtilsClient.drawConnectionPinSixNode(front.right(), descriptor.pinDistance, 1.8f, 1.35f);
+			UtilsClient.drawConnectionPinSixNode(front.right(), pinDistances, 1.8f, 1.35f);
 			GL11.glColor3f(0, 1, 0);
-			UtilsClient.drawConnectionPinSixNode(front.inverse(), descriptor.pinDistance, 1.8f, 1.35f);
+			UtilsClient.drawConnectionPinSixNode(front.inverse(), pinDistances, 1.8f, 1.35f);
 			GL11.glColor3f(0, 0, 1);
-			UtilsClient.drawConnectionPinSixNode(front.left(), descriptor.pinDistance, 1.8f, 1.35f);
+			UtilsClient.drawConnectionPinSixNode(front.left(), pinDistances, 1.8f, 1.35f);
 			GL11.glColor3f(1, 1, 1);
+		}
+
+		if (side.isY()) {
+			front.left().glRotateOnX();
 		}
 
 		descriptor.draw(interpolator.get(), ledOn);

--- a/src/main/java/mods/eln/sixnode/electricalredstoneinput/ElectricalRedstoneInputDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricalredstoneinput/ElectricalRedstoneInputDescriptor.java
@@ -87,6 +87,6 @@ public class ElectricalRedstoneInputDescriptor extends SixNodeDescriptor {
 
 	@Override
 	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
-		return LRDU.Left;
+		return super.getFrontFromPlace(side, player).right();
 	}
 }

--- a/src/main/java/mods/eln/sixnode/electricalredstoneinput/ElectricalRedstoneInputDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricalredstoneinput/ElectricalRedstoneInputDescriptor.java
@@ -1,10 +1,7 @@
 package mods.eln.sixnode.electricalredstoneinput;
 
-import mods.eln.misc.Obj3D;
+import mods.eln.misc.*;
 import mods.eln.misc.Obj3D.Obj3DPart;
-import mods.eln.misc.Utils;
-import mods.eln.misc.UtilsClient;
-import mods.eln.misc.VoltageLevelColor;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.wiki.Data;
 import net.minecraft.entity.player.EntityPlayer;
@@ -86,5 +83,10 @@ public class ElectricalRedstoneInputDescriptor extends SixNodeDescriptor {
 		} else {
 			draw(15);
 		}
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return LRDU.Left;
 	}
 }

--- a/src/main/java/mods/eln/sixnode/electricalredstoneinput/ElectricalRedstoneInputElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalredstoneinput/ElectricalRedstoneInputElement.java
@@ -1,8 +1,5 @@
 package mods.eln.sixnode.electricalredstoneinput;
 
-import java.io.DataOutputStream;
-import java.io.IOException;
-
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
 import mods.eln.misc.Utils;
@@ -19,6 +16,9 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
+import java.io.DataOutputStream;
+import java.io.IOException;
+
 public class ElectricalRedstoneInputElement extends SixNodeElement {
 
 	ElectricalRedstoneInputDescriptor descriptor;
@@ -31,8 +31,7 @@ public class ElectricalRedstoneInputElement extends SixNodeElement {
 
 	public ElectricalRedstoneInputElement(SixNode sixNode, Direction side, SixNodeDescriptor descriptor) {
 		super(sixNode, side, descriptor);
-		front = LRDU.Left;
-    	electricalLoadList.add(outputGate);
+		electricalLoadList.add(outputGate);
     	electricalComponentList.add(outputGateProcess);
     	slowProcessList.add(slowProcess);
     	this.descriptor = (ElectricalRedstoneInputDescriptor) descriptor;

--- a/src/main/java/mods/eln/sixnode/electricalredstoneinput/ElectricalRedstoneInputRender.java
+++ b/src/main/java/mods/eln/sixnode/electricalredstoneinput/ElectricalRedstoneInputRender.java
@@ -1,8 +1,5 @@
 package mods.eln.sixnode.electricalredstoneinput;
 
-import java.io.DataInputStream;
-import java.io.IOException;
-
 import mods.eln.Eln;
 import mods.eln.cable.CableRenderDescriptor;
 import mods.eln.misc.Direction;
@@ -10,6 +7,9 @@ import mods.eln.misc.LRDU;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.node.six.SixNodeElementRender;
 import mods.eln.node.six.SixNodeEntity;
+
+import java.io.DataInputStream;
+import java.io.IOException;
 
 public class ElectricalRedstoneInputRender extends SixNodeElementRender {
 
@@ -27,7 +27,12 @@ public class ElectricalRedstoneInputRender extends SixNodeElementRender {
 		super.draw();
 		drawSignalPin(front.right(), descriptor.pinDistance);
 
-		LRDU.Down.glRotateOnX();
+		if (side.isY()) {
+			front.right().glRotateOnX();
+		} else {
+			LRDU.Down.glRotateOnX();
+		}
+
 		descriptor.draw(redLevel);
 	}
 

--- a/src/main/java/mods/eln/sixnode/electricalredstoneoutput/ElectricalRedstoneOutputDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricalredstoneoutput/ElectricalRedstoneOutputDescriptor.java
@@ -1,10 +1,7 @@
 package mods.eln.sixnode.electricalredstoneoutput;
 
-import mods.eln.misc.Obj3D;
+import mods.eln.misc.*;
 import mods.eln.misc.Obj3D.Obj3DPart;
-import mods.eln.misc.Utils;
-import mods.eln.misc.UtilsClient;
-import mods.eln.misc.VoltageLevelColor;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.wiki.Data;
 import net.minecraft.entity.player.EntityPlayer;
@@ -85,5 +82,10 @@ public class ElectricalRedstoneOutputDescriptor extends SixNodeDescriptor {
 	public void addInformation(ItemStack itemStack, EntityPlayer entityPlayer, List list, boolean par4) {
 		super.addInformation(itemStack, entityPlayer, list, par4);
 		Collections.addAll(list, tr("Converts electrical voltage\ninto a Redstone signal.").split("\n"));
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return LRDU.Left;
 	}
 }

--- a/src/main/java/mods/eln/sixnode/electricalredstoneoutput/ElectricalRedstoneOutputDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricalredstoneoutput/ElectricalRedstoneOutputDescriptor.java
@@ -86,6 +86,6 @@ public class ElectricalRedstoneOutputDescriptor extends SixNodeDescriptor {
 
 	@Override
 	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
-		return LRDU.Left;
+		return super.getFrontFromPlace(side, player).right();
 	}
 }

--- a/src/main/java/mods/eln/sixnode/electricalredstoneoutput/ElectricalRedstoneOutputElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalredstoneoutput/ElectricalRedstoneOutputElement.java
@@ -1,8 +1,5 @@
 package mods.eln.sixnode.electricalredstoneoutput;
 
-import java.io.DataOutputStream;
-import java.io.IOException;
-
 import mods.eln.Eln;
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
@@ -17,6 +14,9 @@ import mods.eln.sim.nbt.NbtElectricalGateInput;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 
+import java.io.DataOutputStream;
+import java.io.IOException;
+
 public class ElectricalRedstoneOutputElement extends SixNodeElement {
 
     public NbtElectricalGateInput inputGate = new NbtElectricalGateInput("inputGate");
@@ -26,8 +26,7 @@ public class ElectricalRedstoneOutputElement extends SixNodeElement {
 
 	public ElectricalRedstoneOutputElement(SixNode sixNode, Direction side, SixNodeDescriptor descriptor) {
 		super(sixNode, side, descriptor);
-		front = LRDU.Left;
-    	electricalLoadList.add(inputGate);
+		electricalLoadList.add(inputGate);
     	slowProcessList.add(slowProcess);
 	}
 

--- a/src/main/java/mods/eln/sixnode/electricalredstoneoutput/ElectricalRedstoneOutputRender.java
+++ b/src/main/java/mods/eln/sixnode/electricalredstoneoutput/ElectricalRedstoneOutputRender.java
@@ -1,8 +1,5 @@
 package mods.eln.sixnode.electricalredstoneoutput;
 
-import java.io.DataInputStream;
-import java.io.IOException;
-
 import mods.eln.Eln;
 import mods.eln.cable.CableRenderDescriptor;
 import mods.eln.misc.Direction;
@@ -10,6 +7,9 @@ import mods.eln.misc.LRDU;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.node.six.SixNodeElementRender;
 import mods.eln.node.six.SixNodeEntity;
+
+import java.io.DataInputStream;
+import java.io.IOException;
 
 public class ElectricalRedstoneOutputRender extends SixNodeElementRender {
 
@@ -30,7 +30,7 @@ public class ElectricalRedstoneOutputRender extends SixNodeElementRender {
 		super.draw();
 
 		drawSignalPin(front.right(), descriptor.pinDistance);
-		
+
 		descriptor.draw(redOutput);
 	}
 

--- a/src/main/java/mods/eln/sixnode/electricalrelay/ElectricalRelayDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricalrelay/ElectricalRelayDescriptor.java
@@ -114,6 +114,6 @@ public class ElectricalRelayDescriptor extends SixNodeDescriptor {
 
 	@Override
 	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
-		return LRDU.Left;
+		return super.getFrontFromPlace(side, player).left();
 	}
 }

--- a/src/main/java/mods/eln/sixnode/electricalrelay/ElectricalRelayDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricalrelay/ElectricalRelayDescriptor.java
@@ -1,9 +1,7 @@
 package mods.eln.sixnode.electricalrelay;
 
-import mods.eln.misc.Obj3D;
+import mods.eln.misc.*;
 import mods.eln.misc.Obj3D.Obj3DPart;
-import mods.eln.misc.UtilsClient;
-import mods.eln.misc.VoltageLevelColor;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.mna.component.Resistor;
@@ -112,5 +110,10 @@ public class ElectricalRelayDescriptor extends SixNodeDescriptor {
 		if (relay0 != null) relay0.draw(factor * (r0rOn - r0rOff) + r0rOff, 0f, 0f, 1f);
 		if (relay1 != null) relay1.draw(factor * (r1rOn - r1rOff) + r1rOff, 0f, 0f, 1f);
 		UtilsClient.enableCulling();
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return LRDU.Left;
 	}
 }

--- a/src/main/java/mods/eln/sixnode/electricalrelay/ElectricalRelayElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalrelay/ElectricalRelayElement.java
@@ -48,8 +48,7 @@ public class ElectricalRelayElement extends SixNodeElement {
 
     	this.descriptor = (ElectricalRelayDescriptor) descriptor;
     	
-		front = LRDU.Left;
-    	electricalLoadList.add(aLoad);
+		electricalLoadList.add(aLoad);
     	electricalLoadList.add(bLoad);
     	electricalComponentList.add(switchResistor);
     	electricalProcessList.add(gateProcess);

--- a/src/main/java/mods/eln/sixnode/electricalsource/ElectricalSourceDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricalsource/ElectricalSourceDescriptor.java
@@ -1,10 +1,8 @@
 package mods.eln.sixnode.electricalsource;
 
 import mods.eln.Eln;
-import mods.eln.misc.Obj3D;
+import mods.eln.misc.*;
 import mods.eln.misc.Obj3D.Obj3DPart;
-import mods.eln.misc.UtilsClient;
-import mods.eln.misc.VoltageLevelColor;
 import mods.eln.node.six.SixNodeDescriptor;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -90,6 +88,15 @@ public class ElectricalSourceDescriptor extends SixNodeDescriptor {
 				}
 				super.renderItem(type, item, data);
 				break;
+		}
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		if (signalSource) {
+			return super.getFrontFromPlace(side, player).left();
+		} else {
+			return super.getFrontFromPlace(side, player);
 		}
 	}
 }

--- a/src/main/java/mods/eln/sixnode/electricalsource/ElectricalSourceRender.java
+++ b/src/main/java/mods/eln/sixnode/electricalsource/ElectricalSourceRender.java
@@ -29,6 +29,8 @@ public class ElectricalSourceRender extends SixNodeElementRender {
 	public void draw() {
 		super.draw();
 
+		front.glRotateOnX();
+
 		descriptor.draw(voltage >= 25);
 	}
 

--- a/src/main/java/mods/eln/sixnode/electricalswitch/ElectricalSwitchDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricalswitch/ElectricalSwitchDescriptor.java
@@ -1,11 +1,8 @@
 package mods.eln.sixnode.electricalswitch;
 
 import mods.eln.cable.CableRenderDescriptor;
-import mods.eln.misc.Obj3D;
+import mods.eln.misc.*;
 import mods.eln.misc.Obj3D.Obj3DPart;
-import mods.eln.misc.Utils;
-import mods.eln.misc.UtilsClient;
-import mods.eln.misc.VoltageLevelColor;
 import mods.eln.node.NodeBase;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.sim.ElectricalLoad;
@@ -148,7 +145,7 @@ public class ElectricalSwitchDescriptor extends SixNodeDescriptor {
 	public void draw(float on, float distance, TileEntity e) {
 		switch (objType) {
             case Button:
-                if (main != null)main.draw();
+                if (main != null) main.draw();
 
                 GL11.glTranslatef(leverTx * on, 0f, 0f);
                 if (lever != null) lever.draw();
@@ -195,5 +192,14 @@ public class ElectricalSwitchDescriptor extends SixNodeDescriptor {
 	public void addInformation(ItemStack itemStack, EntityPlayer entityPlayer, List list, boolean par4) {
 		super.addInformation(itemStack, entityPlayer, list, par4);
 		Collections.addAll(list, tr("Can break an electrical circuit\ninterrupting the current.").split("\n"));
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		if (signalSwitch) {
+			return super.getFrontFromPlace(side, player);
+		} else {
+			return super.getFrontFromPlace(side, player).inverse();
+		}
 	}
 }

--- a/src/main/java/mods/eln/sixnode/electricaltimeout/ElectricalTimeoutDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricaltimeout/ElectricalTimeoutDescriptor.java
@@ -98,6 +98,6 @@ public class ElectricalTimeoutDescriptor extends SixNodeDescriptor {
 
 	@Override
 	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
-		return LRDU.Left;
+		return super.getFrontFromPlace(side, player).right();
 	}
 }

--- a/src/main/java/mods/eln/sixnode/electricaltimeout/ElectricalTimeoutDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricaltimeout/ElectricalTimeoutDescriptor.java
@@ -1,9 +1,7 @@
 package mods.eln.sixnode.electricaltimeout;
 
-import mods.eln.misc.Obj3D;
+import mods.eln.misc.*;
 import mods.eln.misc.Obj3D.Obj3DPart;
-import mods.eln.misc.UtilsClient;
-import mods.eln.misc.VoltageLevelColor;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.wiki.Data;
 import net.minecraft.entity.player.EntityPlayer;
@@ -96,5 +94,10 @@ public class ElectricalTimeoutDescriptor extends SixNodeDescriptor {
 			super.renderItem(type, item, data);
 		}
 		draw(1f);
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return LRDU.Left;
 	}
 }

--- a/src/main/java/mods/eln/sixnode/electricaltimeout/ElectricalTimeoutElement.java
+++ b/src/main/java/mods/eln/sixnode/electricaltimeout/ElectricalTimeoutElement.java
@@ -1,9 +1,5 @@
 package mods.eln.sixnode.electricaltimeout;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
 import mods.eln.misc.Utils;
@@ -19,6 +15,10 @@ import mods.eln.sim.nbt.NbtElectricalGateOutputProcess;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 
 public class ElectricalTimeoutElement extends SixNodeElement {
 
@@ -38,8 +38,7 @@ public class ElectricalTimeoutElement extends SixNodeElement {
 
 	public ElectricalTimeoutElement(SixNode sixNode, Direction side, SixNodeDescriptor descriptor) {
 		super(sixNode, side, descriptor);
-		front = LRDU.Left;
-    	electricalLoadList.add(inputGate);
+		electricalLoadList.add(inputGate);
     	electricalLoadList.add(outputGate);
     	electricalComponentList.add(outputGateProcess);
     	thermalProcessList.add(slowProcess);

--- a/src/main/java/mods/eln/sixnode/electricalvumeter/ElectricalVuMeterDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricalvumeter/ElectricalVuMeterDescriptor.java
@@ -1,11 +1,8 @@
 package mods.eln.sixnode.electricalvumeter;
 
 import mods.eln.Eln;
-import mods.eln.misc.Obj3D;
+import mods.eln.misc.*;
 import mods.eln.misc.Obj3D.Obj3DPart;
-import mods.eln.misc.Utils;
-import mods.eln.misc.UtilsClient;
-import mods.eln.misc.VoltageLevelColor;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.wiki.Data;
 import net.minecraft.entity.player.EntityPlayer;
@@ -14,7 +11,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import org.lwjgl.opengl.GL11;
 
-import java.awt.*;
+import java.awt.Color;
 import java.util.List;
 
 import static mods.eln.i18n.I18N.tr;
@@ -124,5 +121,10 @@ public class ElectricalVuMeterDescriptor extends SixNodeDescriptor {
 		} else {
 			draw(0.0f, 1f, null);
 		}
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return super.getFrontFromPlace(side, player).inverse();
 	}
 }

--- a/src/main/java/mods/eln/sixnode/electricalvumeter/ElectricalVuMeterElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalvumeter/ElectricalVuMeterElement.java
@@ -22,14 +22,12 @@ public class ElectricalVuMeterElement extends SixNodeElement {
 
     public NbtElectricalGateInput inputGate = new NbtElectricalGateInput("inputGate");
     public ElectricalVuMeterSlowProcess slowProcess = new ElectricalVuMeterSlowProcess(this);
-    LRDU front;
     ElectricalVuMeterDescriptor descriptor;
 
 	public ElectricalVuMeterElement(SixNode sixNode, Direction side, SixNodeDescriptor descriptor) {
 		super(sixNode, side, descriptor);
 		this.descriptor = (ElectricalVuMeterDescriptor) descriptor;
-		front = LRDU.Down;
-    	electricalLoadList.add(inputGate);
+		electricalLoadList.add(inputGate);
     	slowProcessList.add(slowProcess);
 	}
 

--- a/src/main/java/mods/eln/sixnode/electricalvumeter/ElectricalVuMeterRender.java
+++ b/src/main/java/mods/eln/sixnode/electricalvumeter/ElectricalVuMeterRender.java
@@ -34,6 +34,10 @@ public class ElectricalVuMeterRender extends SixNodeElementRender {
 		super.draw();
 		drawSignalPin(front, descriptor.pinDistance);
 
+		if (side.isY()) {
+			front.right().glRotateOnX();
+		}
+
 		descriptor.draw(descriptor.onOffOnly ? interpolator.getTarget() : interpolator.get(), UtilsClient.distanceFromClientPlayer(tileEntity), tileEntity);
 	}
 

--- a/src/main/java/mods/eln/sixnode/electricalwatch/ElectricalWatchDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricalwatch/ElectricalWatchDescriptor.java
@@ -1,9 +1,7 @@
 package mods.eln.sixnode.electricalwatch;
 
-import mods.eln.misc.Obj3D;
+import mods.eln.misc.*;
 import mods.eln.misc.Obj3D.Obj3DPart;
-import mods.eln.misc.UtilsClient;
-import mods.eln.misc.VoltageLevelColor;
 import mods.eln.node.six.SixNodeDescriptor;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
@@ -139,5 +137,10 @@ public class ElectricalWatchDescriptor extends SixNodeDescriptor {
 			GL11.glRotatef(90, 1, 0, 0);
 			draw(0.1f, 0.2f, true);
 		}
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return super.getFrontFromPlace(side, player).left();
 	}
 }

--- a/src/main/java/mods/eln/sixnode/electricalwatch/ElectricalWatchRender.java
+++ b/src/main/java/mods/eln/sixnode/electricalwatch/ElectricalWatchRender.java
@@ -1,8 +1,5 @@
 package mods.eln.sixnode.electricalwatch;
 
-import java.io.DataInputStream;
-import java.io.IOException;
-
 import mods.eln.misc.Direction;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.node.six.SixNodeElementInventory;
@@ -10,6 +7,9 @@ import mods.eln.node.six.SixNodeElementRender;
 import mods.eln.node.six.SixNodeEntity;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayer;
+
+import java.io.DataInputStream;
+import java.io.IOException;
 
 public class ElectricalWatchRender extends SixNodeElementRender {
 
@@ -35,6 +35,9 @@ public class ElectricalWatchRender extends SixNodeElementRender {
 			time = oldDate;
 		time += 6000;
 		time %= 24000;
+
+		front.glRotateOnX();
+
 		descriptor.draw(time / 12000f, (time % 1000) / 1000f, upToDate);
 	}
 

--- a/src/main/java/mods/eln/sixnode/electricalweathersensor/ElectricalWeatherSensorDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricalweathersensor/ElectricalWeatherSensorDescriptor.java
@@ -1,11 +1,8 @@
 package mods.eln.sixnode.electricalweathersensor;
 
 import mods.eln.Eln;
-import mods.eln.misc.Obj3D;
+import mods.eln.misc.*;
 import mods.eln.misc.Obj3D.Obj3DPart;
-import mods.eln.misc.Utils;
-import mods.eln.misc.UtilsClient;
-import mods.eln.misc.VoltageLevelColor;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.wiki.Data;
 import net.minecraft.entity.player.EntityPlayer;
@@ -86,5 +83,10 @@ public class ElectricalWeatherSensorDescriptor extends SixNodeDescriptor {
 			GL11.glScalef(2f, 2f, 2f);
 			draw();
 		}
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return super.getFrontFromPlace(side, player).right();
 	}
 }

--- a/src/main/java/mods/eln/sixnode/electricalwindsensor/ElectricalWindSensorDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricalwindsensor/ElectricalWindSensorDescriptor.java
@@ -1,10 +1,7 @@
 package mods.eln.sixnode.electricalwindsensor;
 
-import mods.eln.misc.Obj3D;
+import mods.eln.misc.*;
 import mods.eln.misc.Obj3D.Obj3DPart;
-import mods.eln.misc.Utils;
-import mods.eln.misc.UtilsClient;
-import mods.eln.misc.VoltageLevelColor;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.wiki.Data;
 import net.minecraft.entity.player.EntityPlayer;
@@ -100,5 +97,19 @@ public class ElectricalWindSensorDescriptor extends SixNodeDescriptor {
 
 			draw(0);
 		}
+	}
+
+	@Override
+	public boolean canBePlacedOnSide(EntityPlayer player, Direction side) {
+		if (side.isY()) {
+			Utils.addChatMessage(player, tr("You can't place this block on the floor or the ceiling"));
+			return false;
+		}
+		return super.canBePlacedOnSide(player, side);
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return super.getFrontFromPlace(side, player).right();
 	}
 }

--- a/src/main/java/mods/eln/sixnode/electricasensor/ElectricalSensorDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/electricasensor/ElectricalSensorDescriptor.java
@@ -1,6 +1,8 @@
 package mods.eln.sixnode.electricasensor;
 
 import mods.eln.Eln;
+import mods.eln.misc.Direction;
+import mods.eln.misc.LRDU;
 import mods.eln.misc.Obj3D.Obj3DPart;
 import mods.eln.misc.VoltageLevelColor;
 import mods.eln.node.six.SixNodeDescriptor;
@@ -65,5 +67,10 @@ public class ElectricalSensorDescriptor extends SixNodeDescriptor {
 			list.add(tr("Can measure Voltage/Power/Current"));
 			list.add(tr("Has a signal output."));
 		}
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return super.getFrontFromPlace(side, player).inverse();
 	}
 }

--- a/src/main/java/mods/eln/sixnode/electricasensor/ElectricalSensorElement.java
+++ b/src/main/java/mods/eln/sixnode/electricasensor/ElectricalSensorElement.java
@@ -53,7 +53,6 @@ public class ElectricalSensorElement extends SixNodeElement {
 
 	public ElectricalSensorElement(SixNode sixNode, Direction side, SixNodeDescriptor descriptor) {
 		super(sixNode, side, descriptor);
-		//front = LRDU.Left;
 		this.descriptor = (ElectricalSensorDescriptor) descriptor;
 
 		aLoad = new NbtElectricalLoad("aLoad");

--- a/src/main/java/mods/eln/sixnode/energymeter/EnergyMeterDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/energymeter/EnergyMeterDescriptor.java
@@ -225,6 +225,6 @@ public class EnergyMeterDescriptor extends SixNodeDescriptor {
 
 	@Override
 	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
-		return LRDU.Up;
+		return super.getFrontFromPlace(side, player);
 	}
 }

--- a/src/main/java/mods/eln/sixnode/energymeter/EnergyMeterDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/energymeter/EnergyMeterDescriptor.java
@@ -1,9 +1,7 @@
 package mods.eln.sixnode.energymeter;
 
-import mods.eln.misc.Obj3D;
+import mods.eln.misc.*;
 import mods.eln.misc.Obj3D.Obj3DPart;
-import mods.eln.misc.Utils;
-import mods.eln.misc.VoltageLevelColor;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.wiki.Data;
 import net.minecraft.entity.player.EntityPlayer;
@@ -223,5 +221,10 @@ public class EnergyMeterDescriptor extends SixNodeDescriptor {
 	@Override
 	public void addInformation(ItemStack itemStack, EntityPlayer entityPlayer, List list, boolean par4) {
 		super.addInformation(itemStack, entityPlayer, list, par4);
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return LRDU.Up;
 	}
 }

--- a/src/main/java/mods/eln/sixnode/energymeter/EnergyMeterDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/energymeter/EnergyMeterDescriptor.java
@@ -222,9 +222,4 @@ public class EnergyMeterDescriptor extends SixNodeDescriptor {
 	public void addInformation(ItemStack itemStack, EntityPlayer entityPlayer, List list, boolean par4) {
 		super.addInformation(itemStack, entityPlayer, list, par4);
 	}
-
-	@Override
-	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
-		return super.getFrontFromPlace(side, player);
-	}
 }

--- a/src/main/java/mods/eln/sixnode/energymeter/EnergyMeterElement.java
+++ b/src/main/java/mods/eln/sixnode/energymeter/EnergyMeterElement.java
@@ -1,10 +1,5 @@
 package mods.eln.sixnode.energymeter;
 
-import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-
 import mods.eln.Eln;
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
@@ -28,6 +23,11 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 
 public class EnergyMeterElement extends SixNodeElement {
 
@@ -68,7 +68,6 @@ public class EnergyMeterElement extends SixNodeElement {
 
 	public EnergyMeterElement(SixNode sixNode, Direction side, SixNodeDescriptor descriptor) {
 		super(sixNode, side, descriptor);
-		front = LRDU.Up;
 		shunt.mustUseUltraImpedance();
 
 		electricalLoadList.add(aLoad);

--- a/src/main/java/mods/eln/sixnode/energymeter/EnergyMeterRender.java
+++ b/src/main/java/mods/eln/sixnode/energymeter/EnergyMeterRender.java
@@ -51,16 +51,24 @@ public class EnergyMeterRender extends SixNodeElementRender {
 	public void draw() {
 		super.draw();
 
+		GL11.glPushMatrix();
+
+		float[] pinDistances = descriptor.pinDistance;
+		if (side.isY()) {
+			pinDistances = front.rotate4PinDistances(pinDistances);
+			front.left().glRotateOnX();
+		}
+
 		descriptor.draw(energyStack / Math.pow(10, energyUnit * 3 - 1), timerCouter / (timeUnit == 0 ? 360 : 8640),
 						energyUnit, timeUnit,
 						UtilsClient.distanceFromClientPlayer(tileEntity) < 20);
 
-		//front.glRotateOnX();
+		GL11.glPopMatrix();
 
 		GL11.glColor3f(0.9f, 0f, 0f);
-		drawPowerPinWhite(front, descriptor.pinDistance);
+		drawPowerPinWhite(front, pinDistances);
 		GL11.glColor3f(0f, 0f, 0.9f);
-		drawPowerPinWhite(front.inverse(), descriptor.pinDistance);
+		drawPowerPinWhite(front.inverse(), pinDistances);
 		GL11.glColor3f(1f, 1f, 1f);
 	}
 

--- a/src/main/java/mods/eln/sixnode/groundcable/GroundCableDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/groundcable/GroundCableDescriptor.java
@@ -1,6 +1,8 @@
 package mods.eln.sixnode.groundcable;
 
 import mods.eln.Eln;
+import mods.eln.misc.Direction;
+import mods.eln.misc.LRDU;
 import mods.eln.misc.Obj3D;
 import mods.eln.misc.Obj3D.Obj3DPart;
 import mods.eln.misc.VoltageLevelColor;
@@ -45,5 +47,10 @@ public class GroundCableDescriptor extends SixNodeDescriptor {
 		list.add(tr("Provides a zero volt reference."));
 		Collections.addAll(list, tr("Can be used to set a point of an\nelectrical network to 0V potential.\nFor example to ground negative battery contacts.").split("\n"));
 		list.add(tr("Internal resistance: %1$Ω", Eln.getSmallRs()));
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return super.getFrontFromPlace(side, player).left();
 	}
 }

--- a/src/main/java/mods/eln/sixnode/groundcable/GroundCableRender.java
+++ b/src/main/java/mods/eln/sixnode/groundcable/GroundCableRender.java
@@ -1,8 +1,5 @@
 package mods.eln.sixnode.groundcable;
 
-import java.io.DataInputStream;
-import java.io.IOException;
-
 import mods.eln.Eln;
 import mods.eln.cable.CableRenderDescriptor;
 import mods.eln.misc.Direction;
@@ -15,6 +12,9 @@ import mods.eln.sixnode.electricalcable.ElectricalCableDescriptor;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+
+import java.io.DataInputStream;
+import java.io.IOException;
 
 public class GroundCableRender extends SixNodeElementRender{
 
@@ -35,7 +35,11 @@ public class GroundCableRender extends SixNodeElementRender{
 	@Override
 	public void draw() {
 		super.draw();
-		
+
+		if (side.isY()) {
+			front.glRotateOnX();
+		}
+
 		descriptor.draw();			
 	}
 

--- a/src/main/java/mods/eln/sixnode/hub/HubDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/hub/HubDescriptor.java
@@ -1,5 +1,7 @@
 package mods.eln.sixnode.hub;
 
+import mods.eln.misc.Direction;
+import mods.eln.misc.LRDU;
 import mods.eln.misc.Obj3D;
 import mods.eln.misc.Obj3D.Obj3DPart;
 import mods.eln.misc.VoltageLevelColor;
@@ -72,5 +74,10 @@ public class HubDescriptor extends SixNodeDescriptor {
 	public void addInformation(ItemStack itemStack, EntityPlayer entityPlayer, List list, boolean par4) {
 		super.addInformation(itemStack, entityPlayer, list, par4);
 		Collections.addAll(list, tr("Allows crossing cables\non one single block.").split("\n"));
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return LRDU.Up;
 	}
 }

--- a/src/main/java/mods/eln/sixnode/hub/HubRender.java
+++ b/src/main/java/mods/eln/sixnode/hub/HubRender.java
@@ -1,8 +1,5 @@
 package mods.eln.sixnode.hub;
 
-import java.io.DataInputStream;
-import java.io.IOException;
-
 import mods.eln.cable.CableRenderDescriptor;
 import mods.eln.misc.Direction;
 import mods.eln.misc.Utils;
@@ -14,6 +11,9 @@ import mods.eln.sixnode.electricalcable.ElectricalCableDescriptor;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+
+import java.io.DataInputStream;
+import java.io.IOException;
 
 public class HubRender extends SixNodeElementRender {
 
@@ -35,7 +35,7 @@ public class HubRender extends SixNodeElementRender {
 	@Override
 	public void draw() {
 		super.draw();
-		descriptor.draw(connectionGrid);			
+		descriptor.draw(connectionGrid);
 	}
 
 	@Override

--- a/src/main/java/mods/eln/sixnode/lampsocket/LampSocketDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/lampsocket/LampSocketDescriptor.java
@@ -1,6 +1,7 @@
 package mods.eln.sixnode.lampsocket;
 
-import mods.eln.misc.Color;
+import mods.eln.misc.Direction;
+import mods.eln.misc.LRDU;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.wiki.Data;
 import net.minecraft.entity.player.EntityPlayer;
@@ -119,5 +120,10 @@ public class LampSocketDescriptor extends SixNodeDescriptor {
 				list.add(tr("Angle: %1$° to %2$°", ((int) alphaZMin), ((int) alphaZMax)));
 			}
 		}
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return super.getFrontFromPlace(side, player);
 	}
 }

--- a/src/main/java/mods/eln/sixnode/lampsocket/LampSocketDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/lampsocket/LampSocketDescriptor.java
@@ -1,7 +1,5 @@
 package mods.eln.sixnode.lampsocket;
 
-import mods.eln.misc.Direction;
-import mods.eln.misc.LRDU;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.wiki.Data;
 import net.minecraft.entity.player.EntityPlayer;
@@ -120,10 +118,5 @@ public class LampSocketDescriptor extends SixNodeDescriptor {
 				list.add(tr("Angle: %1$° to %2$°", ((int) alphaZMin), ((int) alphaZMax)));
 			}
 		}
-	}
-
-	@Override
-	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
-		return super.getFrontFromPlace(side, player);
 	}
 }

--- a/src/main/java/mods/eln/sixnode/lampsupply/LampSupplyDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/lampsupply/LampSupplyDescriptor.java
@@ -1,5 +1,7 @@
 package mods.eln.sixnode.lampsupply;
 
+import mods.eln.misc.Direction;
+import mods.eln.misc.LRDU;
 import mods.eln.misc.Obj3D;
 import mods.eln.misc.Obj3D.Obj3DPart;
 import mods.eln.misc.UtilsClient;
@@ -94,5 +96,10 @@ public class LampSupplyDescriptor extends SixNodeDescriptor {
 	public void addInformation(ItemStack itemStack, EntityPlayer entityPlayer, List list, boolean par4) {
 		super.addInformation(itemStack, entityPlayer, list, par4);
 		list.add(tr("Supplies all lamps on the channel."));
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return LRDU.Down;
 	}
 }

--- a/src/main/java/mods/eln/sixnode/lampsupply/LampSupplyDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/lampsupply/LampSupplyDescriptor.java
@@ -100,6 +100,6 @@ public class LampSupplyDescriptor extends SixNodeDescriptor {
 
 	@Override
 	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
-		return LRDU.Down;
+		return super.getFrontFromPlace(side, player).inverse();
 	}
 }

--- a/src/main/java/mods/eln/sixnode/lampsupply/LampSupplyElement.java
+++ b/src/main/java/mods/eln/sixnode/lampsupply/LampSupplyElement.java
@@ -102,9 +102,8 @@ public class LampSupplyElement extends SixNodeElement {
 
 		electricalLoadList.add(powerLoad);
 		slowProcessList.add(lampSupplySlowProcess);
-		front = LRDU.Down;
 
-
+		
 		slowProcessList.add(voltageWatchdog);
 		voltageWatchdog
 		 .set(powerLoad)

--- a/src/main/java/mods/eln/sixnode/lampsupply/LampSupplyRender.java
+++ b/src/main/java/mods/eln/sixnode/lampsupply/LampSupplyRender.java
@@ -44,9 +44,15 @@ public class LampSupplyRender extends SixNodeElementRender {
 	public void draw() {
 		super.draw();
 
-		drawPowerPin(new float[] { 4, 4, 5, 5 });
+		float[] pinDistances = new float[] { 4.98f, 4.98f, 5.98f, 5.98f};
 
-		LRDU.Down.glRotateOnX();
+		if (side.isY()) {
+			drawPowerPin(front.rotate4PinDistances(pinDistances));
+			front.glRotateOnX();
+		} else {
+			drawPowerPin(pinDistances);
+			LRDU.Down.glRotateOnX();
+		}
 		descriptor.draw(interpolator.get());
 	}
 

--- a/src/main/java/mods/eln/sixnode/modbusrtu/ModbusRtuDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/modbusrtu/ModbusRtuDescriptor.java
@@ -1,9 +1,7 @@
 package mods.eln.sixnode.modbusrtu;
 
-import mods.eln.misc.Obj3D;
+import mods.eln.misc.*;
 import mods.eln.misc.Obj3D.Obj3DPart;
-import mods.eln.misc.UtilsClient;
-import mods.eln.misc.VoltageLevelColor;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.wiki.Data;
 import net.minecraft.entity.player.EntityPlayer;
@@ -117,5 +115,10 @@ public class ModbusRtuDescriptor extends SixNodeDescriptor {
 				display.draw();
 			}
 		}
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return super.getFrontFromPlace(side, player);
 	}
 }

--- a/src/main/java/mods/eln/sixnode/modbusrtu/ModbusRtuDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/modbusrtu/ModbusRtuDescriptor.java
@@ -116,9 +116,4 @@ public class ModbusRtuDescriptor extends SixNodeDescriptor {
 			}
 		}
 	}
-
-	@Override
-	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
-		return super.getFrontFromPlace(side, player);
-	}
 }

--- a/src/main/java/mods/eln/sixnode/modbusrtu/ModbusRtuElement.java
+++ b/src/main/java/mods/eln/sixnode/modbusrtu/ModbusRtuElement.java
@@ -1,13 +1,7 @@
 package mods.eln.sixnode.modbusrtu;
 
-import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-
+import com.serotonin.modbus4j.ProcessImage;
+import com.serotonin.modbus4j.exception.IllegalDataAddressException;
 import mods.eln.Eln;
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
@@ -28,8 +22,13 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 
-import com.serotonin.modbus4j.ProcessImage;
-import com.serotonin.modbus4j.exception.IllegalDataAddressException;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 
 public class ModbusRtuElement extends SixNodeElement implements ProcessImage {
 
@@ -173,7 +172,16 @@ public class ModbusRtuElement extends SixNodeElement implements ProcessImage {
 
 	@Override
 	public boolean onBlockActivated(EntityPlayer entityPlayer, Direction side, float vx, float vy, float vz) {
-		return false;
+		if (Utils.isPlayerUsingWrench(entityPlayer)) {
+			if (side.isY()) {
+				front = front.getNextClockwise();
+				sixNode.reconnect();
+				sixNode.setNeedPublish(true);
+			}
+			return true;
+		} else {
+			return false;
+		}
 	}
 
 	@Override

--- a/src/main/java/mods/eln/sixnode/modbusrtu/ModbusRtuRender.java
+++ b/src/main/java/mods/eln/sixnode/modbusrtu/ModbusRtuRender.java
@@ -1,21 +1,17 @@
 package mods.eln.sixnode.modbusrtu;
 
-import java.io.DataInputStream;
-import java.io.IOException;
-import java.util.HashMap;
-
 import mods.eln.Eln;
 import mods.eln.cable.CableRenderDescriptor;
-import mods.eln.misc.Coordonate;
-import mods.eln.misc.Direction;
-import mods.eln.misc.LRDU;
-import mods.eln.misc.PhysicalInterpolator;
-import mods.eln.misc.Utils;
+import mods.eln.misc.*;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.node.six.SixNodeElementRender;
 import mods.eln.node.six.SixNodeEntity;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayer;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.HashMap;
 
 public class ModbusRtuRender extends SixNodeElementRender {
 
@@ -47,7 +43,11 @@ public class ModbusRtuRender extends SixNodeElementRender {
 	public void draw() {
 		super.draw();
 
-		LRDU.Down.glRotateOnX();
+        if (side.isY()) {
+            front.inverse().glRotateOnX();
+        } else {
+            LRDU.Down.glRotateOnX();
+        }
 
 		descriptor.draw(interpolator.get(), modbusActivityTimeout > 0, modbusErrorTimeout > 0);
 	}

--- a/src/main/java/mods/eln/sixnode/powercapacitorsix/PowerCapacitorSixDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/powercapacitorsix/PowerCapacitorSixDescriptor.java
@@ -2,6 +2,8 @@ package mods.eln.sixnode.powercapacitorsix;
 
 import mods.eln.Eln;
 import mods.eln.item.DielectricItem;
+import mods.eln.misc.Direction;
+import mods.eln.misc.LRDU;
 import mods.eln.misc.Obj3D;
 import mods.eln.misc.Obj3D.Obj3DPart;
 import mods.eln.misc.VoltageLevelColor;
@@ -110,5 +112,10 @@ public class PowerCapacitorSixDescriptor extends SixNodeDescriptor {
 	@Override
 	public void addInformation(ItemStack itemStack, EntityPlayer entityPlayer, List list, boolean par4) {
 		super.addInformation(itemStack, entityPlayer, list, par4);
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return super.getFrontFromPlace(side, player).left();
 	}
 }

--- a/src/main/java/mods/eln/sixnode/powerinductorsix/PowerInductorSixDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/powerinductorsix/PowerInductorSixDescriptor.java
@@ -2,6 +2,8 @@ package mods.eln.sixnode.powerinductorsix;
 
 import mods.eln.Eln;
 import mods.eln.item.FerromagneticCoreDescriptor;
+import mods.eln.misc.Direction;
+import mods.eln.misc.LRDU;
 import mods.eln.misc.Obj3D;
 import mods.eln.misc.Obj3D.Obj3DPart;
 import mods.eln.misc.VoltageLevelColor;
@@ -107,5 +109,10 @@ public class PowerInductorSixDescriptor extends SixNodeDescriptor {
 	@Override
 	public void addInformation(ItemStack itemStack, EntityPlayer entityPlayer, List list, boolean par4) {
 		super.addInformation(itemStack, entityPlayer, list, par4);
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return super.getFrontFromPlace(side, player).left();
 	}
 }

--- a/src/main/java/mods/eln/sixnode/powerinductorsix/PowerInductorSixRender.java
+++ b/src/main/java/mods/eln/sixnode/powerinductorsix/PowerInductorSixRender.java
@@ -8,7 +8,6 @@ import mods.eln.node.six.SixNodeElementRender;
 import mods.eln.node.six.SixNodeEntity;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayer;
-import org.lwjgl.opengl.GL11;
 
 public class PowerInductorSixRender extends SixNodeElementRender {
 
@@ -24,8 +23,7 @@ public class PowerInductorSixRender extends SixNodeElementRender {
 
 	@Override
 	public void draw() {
-		GL11.glRotatef(90, 1, 0, 0);
-		front.glRotateOnX();
+		front.left().glRotateOnX();
 		descriptor.draw();
 	}
 

--- a/src/main/java/mods/eln/sixnode/powersocket/PowerSocketDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/powersocket/PowerSocketDescriptor.java
@@ -1,5 +1,7 @@
 package mods.eln.sixnode.powersocket;
 
+import mods.eln.misc.Direction;
+import mods.eln.misc.LRDU;
 import mods.eln.misc.Obj3D;
 import mods.eln.misc.Obj3D.Obj3DPart;
 import mods.eln.misc.VoltageLevelColor;
@@ -93,5 +95,10 @@ public class PowerSocketDescriptor extends SixNodeDescriptor {
 	public void addInformation(ItemStack itemStack, EntityPlayer entityPlayer, List list, boolean par4) {
 		super.addInformation(itemStack, entityPlayer, list, par4);
 		Collections.addAll(list, tr("Supplies any device\nplugged in with energy.").split("\n"));
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return LRDU.Down;
 	}
 }

--- a/src/main/java/mods/eln/sixnode/powersocket/PowerSocketElement.java
+++ b/src/main/java/mods/eln/sixnode/powersocket/PowerSocketElement.java
@@ -68,7 +68,6 @@ public class PowerSocketElement extends SixNodeElement {
 		electricalComponentList.add(loadResistor);
 		slowProcessList.add(PowerSocketSlowProcess);
 		loadResistor.highImpedance();
-		front = LRDU.Down;
 		this.descriptor = (PowerSocketDescriptor) descriptor;
 
 		slowProcessList.add(voltageWatchdog);

--- a/src/main/java/mods/eln/sixnode/resistor/ResistorDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/resistor/ResistorDescriptor.java
@@ -1,6 +1,8 @@
 package mods.eln.sixnode.resistor;
 
 import mods.eln.Eln;
+import mods.eln.misc.Direction;
+import mods.eln.misc.LRDU;
 import mods.eln.misc.Obj3D;
 import mods.eln.misc.VoltageLevelColor;
 import mods.eln.misc.series.ISerie;
@@ -116,5 +118,10 @@ public class ResistorDescriptor extends SixNodeDescriptor {
     @Override
     public void addInformation(ItemStack itemStack, EntityPlayer entityPlayer, List list, boolean par4) {
         super.addInformation(itemStack, entityPlayer, list, par4);
+    }
+
+    @Override
+    public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+        return super.getFrontFromPlace(side, player).left();
     }
 }

--- a/src/main/java/mods/eln/sixnode/thermalsensor/ThermalSensorDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/thermalsensor/ThermalSensorDescriptor.java
@@ -1,5 +1,7 @@
 package mods.eln.sixnode.thermalsensor;
 
+import mods.eln.misc.Direction;
+import mods.eln.misc.LRDU;
 import mods.eln.misc.Obj3D;
 import mods.eln.misc.Obj3D.Obj3DPart;
 import mods.eln.misc.VoltageLevelColor;
@@ -59,5 +61,10 @@ public class ThermalSensorDescriptor extends SixNodeDescriptor {
 	void draw(boolean renderAdapter) {
 		if (main != null) main.draw();
         if (renderAdapter && adapter != null) adapter.draw();
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return super.getFrontFromPlace(side, player).inverse();
 	}
 }

--- a/src/main/java/mods/eln/sixnode/thermalsensor/ThermalSensorElement.java
+++ b/src/main/java/mods/eln/sixnode/thermalsensor/ThermalSensorElement.java
@@ -1,9 +1,5 @@
 package mods.eln.sixnode.thermalsensor;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-
 import mods.eln.Eln;
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
@@ -25,6 +21,10 @@ import net.minecraft.inventory.Container;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
 public class ThermalSensorElement extends SixNodeElement {
 
     public ThermalSensorDescriptor descriptor;
@@ -35,7 +35,6 @@ public class ThermalSensorElement extends SixNodeElement {
     public ThermalSensorProcess slowProcess = new ThermalSensorProcess(this);
 
     SixNodeElementInventory inventory = new SixNodeElementInventory(1, 64, this);
-    LRDU front;
 
     static final byte powerType = 0, temperatureType = 1;
     int typeOfSensor = temperatureType;
@@ -46,7 +45,6 @@ public class ThermalSensorElement extends SixNodeElement {
     
 	public ThermalSensorElement(SixNode sixNode, Direction side, SixNodeDescriptor descriptor) {
 		super(sixNode, side, descriptor);
-		front = LRDU.Left;
 		thermalLoadList.add(thermalLoad);
 		electricalLoadList.add(outputGate);
 		electricalComponentList.add(outputGateProcess);

--- a/src/main/java/mods/eln/sixnode/wirelesssignal/repeater/WirelessSignalRepeaterDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/wirelesssignal/repeater/WirelessSignalRepeaterDescriptor.java
@@ -81,6 +81,6 @@ public class WirelessSignalRepeaterDescriptor extends SixNodeDescriptor {
 
 	@Override
 	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
-		return LRDU.Down;
+		return super.getFrontFromPlace(side, player).inverse();
 	}
 }

--- a/src/main/java/mods/eln/sixnode/wirelesssignal/repeater/WirelessSignalRepeaterDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/wirelesssignal/repeater/WirelessSignalRepeaterDescriptor.java
@@ -1,10 +1,13 @@
 package mods.eln.sixnode.wirelesssignal.repeater;
 
+import mods.eln.misc.Direction;
+import mods.eln.misc.LRDU;
 import mods.eln.misc.Obj3D;
 import mods.eln.misc.Obj3D.Obj3DPart;
 import mods.eln.misc.VoltageLevelColor;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.wiki.Data;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import org.lwjgl.opengl.GL11;
@@ -74,5 +77,10 @@ public class WirelessSignalRepeaterDescriptor extends SixNodeDescriptor {
 			UtilsClient.ledOnOffColor(connection);
 			UtilsClient.drawLight(led);
 		}*/
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return LRDU.Down;
 	}
 }

--- a/src/main/java/mods/eln/sixnode/wirelesssignal/repeater/WirelessSignalRepeaterElement.java
+++ b/src/main/java/mods/eln/sixnode/wirelesssignal/repeater/WirelessSignalRepeaterElement.java
@@ -30,8 +30,6 @@ public class WirelessSignalRepeaterElement extends SixNodeElement {
 
 		slowProcessList.add(slowProcess);
 		
-		front = LRDU.Down;
-
 		IWirelessSignalSpot.spots.add(slowProcess);
 	}
 

--- a/src/main/java/mods/eln/sixnode/wirelesssignal/repeater/WirelessSignalRepeaterRender.java
+++ b/src/main/java/mods/eln/sixnode/wirelesssignal/repeater/WirelessSignalRepeaterRender.java
@@ -25,8 +25,6 @@ public class WirelessSignalRepeaterRender extends SixNodeElementRender {
 	@Override
 	public void draw() {
 		super.draw();
-
-		// drawSignalPin(new float[] { 2, 2, 2, 2 });
 		front.glRotateOnX();
 		descriptor.draw();
 	}

--- a/src/main/java/mods/eln/sixnode/wirelesssignal/rx/WirelessSignalRxDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/wirelesssignal/rx/WirelessSignalRxDescriptor.java
@@ -75,6 +75,6 @@ public class WirelessSignalRxDescriptor extends SixNodeDescriptor {
 
 	@Override
 	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
-		return LRDU.Down;
+		return super.getFrontFromPlace(side, player).inverse();
 	}
 }

--- a/src/main/java/mods/eln/sixnode/wirelesssignal/rx/WirelessSignalRxDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/wirelesssignal/rx/WirelessSignalRxDescriptor.java
@@ -1,11 +1,10 @@
 package mods.eln.sixnode.wirelesssignal.rx;
 
-import mods.eln.misc.Obj3D;
+import mods.eln.misc.*;
 import mods.eln.misc.Obj3D.Obj3DPart;
-import mods.eln.misc.UtilsClient;
-import mods.eln.misc.VoltageLevelColor;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.wiki.Data;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import org.lwjgl.opengl.GL11;
@@ -72,5 +71,10 @@ public class WirelessSignalRxDescriptor extends SixNodeDescriptor {
 			UtilsClient.ledOnOffColor(connection);
 			UtilsClient.drawLight(led);
 		}
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return LRDU.Down;
 	}
 }

--- a/src/main/java/mods/eln/sixnode/wirelesssignal/rx/WirelessSignalRxElement.java
+++ b/src/main/java/mods/eln/sixnode/wirelesssignal/rx/WirelessSignalRxElement.java
@@ -53,8 +53,6 @@ public class WirelessSignalRxElement extends SixNodeElement {
 		electricalComponentList.add(outputGateProcess);	
 		electricalProcessList.add(slowProcess);
 		
-		front = LRDU.Down;
-        
 		aggregators = new IWirelessSignalAggregator[3];
 		aggregators[0] = new BiggerAggregator();
 		aggregators[1] = new SmallerAggregator();

--- a/src/main/java/mods/eln/sixnode/wirelesssignal/source/WirelessSignalSourceDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/wirelesssignal/source/WirelessSignalSourceDescriptor.java
@@ -1,12 +1,9 @@
 package mods.eln.sixnode.wirelesssignal.source;
 
-import mods.eln.misc.Direction;
-import mods.eln.misc.LRDU;
 import mods.eln.misc.VoltageLevelColor;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.sixnode.electricalgatesource.ElectricalGateSourceRenderObj;
 import mods.eln.wiki.Data;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -67,10 +64,5 @@ public class WirelessSignalSourceDescriptor extends SixNodeDescriptor {
 			GL11.glScalef(1.5f, 1.5f, 1.5f);
 			draw(0f, 1f, null);
 		}
-	}
-
-	@Override
-	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
-		return LRDU.Down;
 	}
 }

--- a/src/main/java/mods/eln/sixnode/wirelesssignal/source/WirelessSignalSourceDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/wirelesssignal/source/WirelessSignalSourceDescriptor.java
@@ -1,9 +1,12 @@
 package mods.eln.sixnode.wirelesssignal.source;
 
+import mods.eln.misc.Direction;
+import mods.eln.misc.LRDU;
 import mods.eln.misc.VoltageLevelColor;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.sixnode.electricalgatesource.ElectricalGateSourceRenderObj;
 import mods.eln.wiki.Data;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -64,5 +67,10 @@ public class WirelessSignalSourceDescriptor extends SixNodeDescriptor {
 			GL11.glScalef(1.5f, 1.5f, 1.5f);
 			draw(0f, 1f, null);
 		}
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return LRDU.Down;
 	}
 }

--- a/src/main/java/mods/eln/sixnode/wirelesssignal/source/WirelessSignalSourceElement.java
+++ b/src/main/java/mods/eln/sixnode/wirelesssignal/source/WirelessSignalSourceElement.java
@@ -1,11 +1,5 @@
 package mods.eln.sixnode.wirelesssignal.source;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-
 import mods.eln.misc.Coordonate;
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
@@ -22,6 +16,12 @@ import mods.eln.sixnode.wirelesssignal.tx.WirelessSignalTxElement.LightningGlitc
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
 
 public class WirelessSignalSourceElement extends SixNodeElement implements IWirelessSignalTx {
     
@@ -40,7 +40,6 @@ public class WirelessSignalSourceElement extends SixNodeElement implements IWire
     public WirelessSignalSourceElement(SixNode sixNode, Direction side, SixNodeDescriptor descriptor) {
 		super(sixNode, side, descriptor);
 
-		front = LRDU.Down;
 		this.descriptor = (WirelessSignalSourceDescriptor) descriptor;
 		WirelessSignalTxElement.channelRegister(this);
 		slowProcessList.add(lightningGlitchProcess = new LightningGlitchProcess(getCoordonate()));

--- a/src/main/java/mods/eln/sixnode/wirelesssignal/source/WirelessSignalSourceRender.java
+++ b/src/main/java/mods/eln/sixnode/wirelesssignal/source/WirelessSignalSourceRender.java
@@ -34,7 +34,7 @@ public class WirelessSignalSourceRender extends SixNodeElementRender {
 	@Override
 	public void draw() {
 		super.draw();
-		LRDU.Down.glRotateOnX();
+		//LRDU.Down.glRotateOnX();
 		descriptor.draw(interpolator.get(), UtilsClient.distanceFromClientPlayer(this.tileEntity), tileEntity);
 	}
 	

--- a/src/main/java/mods/eln/sixnode/wirelesssignal/source/WirelessSignalSourceRender.java
+++ b/src/main/java/mods/eln/sixnode/wirelesssignal/source/WirelessSignalSourceRender.java
@@ -34,7 +34,6 @@ public class WirelessSignalSourceRender extends SixNodeElementRender {
 	@Override
 	public void draw() {
 		super.draw();
-		//LRDU.Down.glRotateOnX();
 		descriptor.draw(interpolator.get(), UtilsClient.distanceFromClientPlayer(this.tileEntity), tileEntity);
 	}
 	

--- a/src/main/java/mods/eln/sixnode/wirelesssignal/tx/WirelessSignalTxDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/wirelesssignal/tx/WirelessSignalTxDescriptor.java
@@ -1,10 +1,13 @@
 package mods.eln.sixnode.wirelesssignal.tx;
 
+import mods.eln.misc.Direction;
+import mods.eln.misc.LRDU;
 import mods.eln.misc.Obj3D;
 import mods.eln.misc.Obj3D.Obj3DPart;
 import mods.eln.misc.VoltageLevelColor;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.wiki.Data;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import org.lwjgl.opengl.GL11;
@@ -68,5 +71,10 @@ public class WirelessSignalTxDescriptor extends SixNodeDescriptor {
 			}
 			draw();
 		}
+	}
+
+	@Override
+	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
+		return LRDU.Down;
 	}
 }

--- a/src/main/java/mods/eln/sixnode/wirelesssignal/tx/WirelessSignalTxDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/wirelesssignal/tx/WirelessSignalTxDescriptor.java
@@ -75,6 +75,6 @@ public class WirelessSignalTxDescriptor extends SixNodeDescriptor {
 
 	@Override
 	public LRDU getFrontFromPlace(Direction side, EntityPlayer player) {
-		return LRDU.Down;
+		return super.getFrontFromPlace(side, player).inverse();
 	}
 }

--- a/src/main/java/mods/eln/sixnode/wirelesssignal/tx/WirelessSignalTxElement.java
+++ b/src/main/java/mods/eln/sixnode/wirelesssignal/tx/WirelessSignalTxElement.java
@@ -42,7 +42,6 @@ public class WirelessSignalTxElement extends SixNodeElement implements IWireless
 		super(sixNode, side, descriptor);
 		electricalLoadList.add(inputGate);
 		slowProcessList.add(lightningGlitchProcess = new LightningGlitchProcess(getCoordonate()));
-		front = LRDU.Down;
 		this.descriptor = (WirelessSignalTxDescriptor) descriptor;
 		channelRegister(this);
 	}


### PR DESCRIPTION
Not quite ready to merge, but I would like to start the discussion about this feature.

I would like to achieve that each SixNodeDescriptor can determine the front direction of the element at the creation by overriding a method like it is possible for transparent nodes (getFrontFromPlace() method).

I did the needed changes in SixNode code to enable this and changed for all six node elements that did this in the constructor to use the actual method in the descriptor.

In the data logger I experimented with the idea, that if you place a block on a wall, the direction is always "up", but if you place the block on the ground or the ceiling, up is in the direction the player is actually looking horizontally. This would improve the user experience as most of the time six nodes are placed automatically as the user expects it.

@Electrical-Age/devs What do you think? 
