### PR TITLE
Fix Modbus TCP Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ eclipse
 *.json
 options.txt
 /out
+/classes
 
 # IntelliJ
 .idea

--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -268,6 +268,7 @@ public class Eln {
 	public static String dicTungstenOre, dicTungstenDust, dicTungstenIngot;
 	public static final ArrayList<OreScannerConfigElement> oreScannerConfig = new ArrayList<OreScannerConfigElement>();
 	public static boolean modbusEnable = false;
+	public static int modbusPort;
 
 	float xRayScannerRange;
 	boolean addOtherModOreToXRay;
@@ -349,6 +350,7 @@ public class Eln {
 
 
 		modbusEnable = config.get("modbus", "enable", false).getBoolean(false);
+		modbusPort = config.get("modbus", "port", 1502).getInt(1502);
 		debugEnabled = config.get("debug", "enable", false).getBoolean(false);
 
 		explosionEnable = config.get("gameplay", "explosion", true).getBoolean(true);
@@ -930,7 +932,7 @@ public class Eln {
 
 	@EventHandler
 	public void onServerStart(FMLServerAboutToStartEvent ev) {
-		modbusServer = new ModbusTcpServer();
+		modbusServer = new ModbusTcpServer(modbusPort);
 		TeleporterElement.teleporterList.clear();
 		//tileEntityDestructor.clear();
 		LightBlockEntity.observers.clear();

--- a/src/main/java/mods/eln/sixnode/modbusrtu/ModbusTcpServer.kt
+++ b/src/main/java/mods/eln/sixnode/modbusrtu/ModbusTcpServer.kt
@@ -1,11 +1,9 @@
 package mods.eln.sixnode.modbusrtu
 
 import mods.eln.Eln
+import mods.eln.misc.Utils
 import java.io.OutputStream
-import java.net.InetAddress
-import java.net.InetSocketAddress
-import java.net.ServerSocket
-import java.net.Socket
+import java.net.*
 import java.nio.ByteBuffer
 import java.util.*
 
@@ -15,13 +13,19 @@ class ModbusTcpServer(port: Int = 1502) {
         private val OutputBufferSize = InputBufferSize
     }
 
-    private var server = ServerSocket()
+    private val server = ServerSocket()
     private val connections: MutableList<ConnectionHandler> = ArrayList()
     private val slaves = TreeMap<Int, IModbusSlave>()
 
     init {
         if (Eln.modbusEnable) {
-            server.bind(InetSocketAddress(port))
+            try {
+                server.bind(InetSocketAddress(port))
+            } catch (e: BindException){
+                Utils.println("Exception while binding Modbus RTU Server. Modbus server disabled!")
+                server.close()
+                e.printStackTrace();
+            }
             start()
         }
         else {

--- a/src/main/java/mods/eln/sixnode/modbusrtu/ModbusTcpServer.kt
+++ b/src/main/java/mods/eln/sixnode/modbusrtu/ModbusTcpServer.kt
@@ -2,6 +2,8 @@ package mods.eln.sixnode.modbusrtu
 
 import mods.eln.Eln
 import java.io.OutputStream
+import java.net.InetAddress
+import java.net.InetSocketAddress
 import java.net.ServerSocket
 import java.net.Socket
 import java.nio.ByteBuffer
@@ -13,13 +15,17 @@ class ModbusTcpServer(port: Int = 1502) {
         private val OutputBufferSize = InputBufferSize
     }
 
-    private val server = ServerSocket(port)
+    private var server = ServerSocket()
     private val connections: MutableList<ConnectionHandler> = ArrayList()
     private val slaves = TreeMap<Int, IModbusSlave>()
 
     init {
         if (Eln.modbusEnable) {
+            server.bind(InetSocketAddress(port))
             start()
+        }
+        else {
+            server.close()
         }
     }
 


### PR DESCRIPTION
Closes #451 
The server was attempting to bind to port before checking if it was enabled or not.
This PR:
- Only attempts to bind if enabled, closes server otherwise.
- Makes the port configurable
- Catches exceptions, and let's the user know there's a problem instead of crashing if bind fails.
- Adds some directory IntelliJ spat out to .gitignore
