### PR TITLE
Add WAILA

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,12 +61,21 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven {
+        name = "codechicken"
+        url = "http://chickenbones.net/maven"
+    }
+    maven {
+        name = "mobiusstrip"
+        url = "http://mobiusstrip.eu/maven/"
+    }
 }
 
 dependencies {
     external files("libs/commons-math3-3.3.jar")
     external "org.jetbrains.kotlin:kotlin-runtime:$kotlin_version"
     external "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile "mcp.mobius.waila:Waila:1.5.11-RC2-NONEI_1.7.10"
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     external files("libs/commons-math3-3.3.jar")
     external "org.jetbrains.kotlin:kotlin-runtime:$kotlin_version"
     external "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    compile "mcp.mobius.waila:Waila:1.5.11-RC2-NONEI_1.7.10"
+    compile "mcp.mobius.waila:Waila:1.5.11-RC2-NONEI_1.7.10:dev"
 }
 
 jar {

--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -10,8 +10,7 @@ import cpw.mods.fml.common.network.simpleimpl.SimpleNetworkWrapper;
 import cpw.mods.fml.common.registry.EntityRegistry;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
-import mods.eln.achievepackets.AchievePacket;
-import mods.eln.achievepackets.AchievePacketHandler;
+import mods.eln.packets.*;
 import mods.eln.cable.CableRenderDescriptor;
 import mods.eln.client.ClientKeyHandler;
 import mods.eln.client.SoundLoader;
@@ -302,8 +301,11 @@ public class Eln {
 	@EventHandler
 	public void preInit(FMLPreInitializationEvent event) {
 		
-		elnNetwork = NetworkRegistry.INSTANCE.newSimpleChannel(this.channelName);
+		elnNetwork = NetworkRegistry.INSTANCE.newSimpleChannel("eln");
 		elnNetwork.registerMessage(AchievePacketHandler.class, AchievePacket.class, 0, Side.SERVER);
+		elnNetwork.registerMessage(TransparentNodeRequestPacketHandler.class, TransparentNodeRequestPacket.class, 1, Side.SERVER);
+		elnNetwork.registerMessage(NodeReturnPacketHandler.class, NodeReturnPacket.class, 2, Side.CLIENT);
+
 		
 		ModContainer container = FMLCommonHandler.instance().findContainerFor(this);
 		// LanguageRegistry.instance().loadLanguagesFor(container, Side.CLIENT);
@@ -740,6 +742,8 @@ public class Eln {
 
 		MinecraftForge.EVENT_BUS.register(new ElnForgeEventsHandler());
 		FMLCommonHandler.instance().bus().register(new ElnFMLEventsHandler());
+
+		FMLInterModComms.sendMessage("Waila", "register", "mods.eln.integration.waila.WailaIntegration.callbackRegister");
 
 		Utils.println("Electrical age init done");
 	}

--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -189,7 +189,7 @@ public class Eln {
 
 	public static final String channelName = "miaouMod";
 	public ArrayList<IConfigSharing> configShared = new ArrayList<IConfigSharing>();
-	public static SimpleNetworkWrapper achNetwork;
+	public static SimpleNetworkWrapper elnNetwork;
 
 	// public static final double networkSerializeValueFactor = 100.0;
 	// public static final byte packetNodeSerialized24bitPosition = 11;
@@ -297,11 +297,13 @@ public class Eln {
 
 	double stdHalfLife = 2 * Utils.minecraftDay;
 
+	public static boolean wailaEasyMode = false;
+
 	@EventHandler
 	public void preInit(FMLPreInitializationEvent event) {
 		
-		achNetwork = NetworkRegistry.INSTANCE.newSimpleChannel("achChannel");
-		achNetwork.registerMessage(AchievePacketHandler.class, AchievePacket.class, 0, Side.SERVER);
+		elnNetwork = NetworkRegistry.INSTANCE.newSimpleChannel(this.channelName);
+		elnNetwork.registerMessage(AchievePacketHandler.class, AchievePacket.class, 0, Side.SERVER);
 		
 		ModContainer container = FMLCommonHandler.instance().findContainerFor(this);
 		// LanguageRegistry.instance().loadLanguagesFor(container, Side.CLIENT);

--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -430,6 +430,8 @@ public class Eln {
 
 		wirelessTxRange = config.get("wireless", "txRange", 32).getInt();
 
+		wailaEasyMode = config.get("balancing", "wailaEasyMode", false, "Display detailed WAILA info on batteries").getBoolean(false);
+
 		config.save();
 
 

--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -301,7 +301,7 @@ public class Eln {
 	@EventHandler
 	public void preInit(FMLPreInitializationEvent event) {
 		
-		elnNetwork = NetworkRegistry.INSTANCE.newSimpleChannel("eln");
+		elnNetwork = NetworkRegistry.INSTANCE.newSimpleChannel("electrical-age");
 		elnNetwork.registerMessage(AchievePacketHandler.class, AchievePacket.class, 0, Side.SERVER);
 		elnNetwork.registerMessage(TransparentNodeRequestPacketHandler.class, TransparentNodeRequestPacket.class, 1, Side.SERVER);
 		elnNetwork.registerMessage(NodeReturnPacketHandler.class, NodeReturnPacket.class, 2, Side.CLIENT);
@@ -432,7 +432,7 @@ public class Eln {
 
 		wirelessTxRange = config.get("wireless", "txRange", 32).getInt();
 
-		wailaEasyMode = config.get("balancing", "wailaEasyMode", false, "Display detailed WAILA info on batteries").getBoolean(false);
+		wailaEasyMode = config.get("balancing", "wailaEasyMode", false, "Display more detailed WAILA info on some machines").getBoolean(false);
 
 		config.save();
 

--- a/src/main/java/mods/eln/eventhandlers/ElnFMLEventsHandler.java
+++ b/src/main/java/mods/eln/eventhandlers/ElnFMLEventsHandler.java
@@ -3,7 +3,7 @@ package mods.eln.eventhandlers;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent.ItemCraftedEvent;
 import mods.eln.Eln;
-import mods.eln.achievepackets.AchievePacket;
+import mods.eln.packets.AchievePacket;
 
 public class ElnFMLEventsHandler {
 

--- a/src/main/java/mods/eln/eventhandlers/ElnFMLEventsHandler.java
+++ b/src/main/java/mods/eln/eventhandlers/ElnFMLEventsHandler.java
@@ -13,7 +13,7 @@ public class ElnFMLEventsHandler {
     @SuppressWarnings("unused")
     public void onCraft(ItemCraftedEvent e) {
         if (e.crafting.getUnlocalizedName().toLowerCase().equals("50v_macerator")) {
-            Eln.achNetwork.sendToServer(p);
+            Eln.elnNetwork.sendToServer(p);
         }
     }
 }

--- a/src/main/java/mods/eln/eventhandlers/ElnForgeEventsHandler.java
+++ b/src/main/java/mods/eln/eventhandlers/ElnForgeEventsHandler.java
@@ -17,7 +17,7 @@ public class ElnForgeEventsHandler {
     @SuppressWarnings("unused")
     public void openGuide(GuiOpenEvent e) {
         if (e.gui instanceof Root) {
-            Eln.achNetwork.sendToServer(p);
+            Eln.elnNetwork.sendToServer(p);
         }
     }
 }

--- a/src/main/java/mods/eln/eventhandlers/ElnForgeEventsHandler.java
+++ b/src/main/java/mods/eln/eventhandlers/ElnForgeEventsHandler.java
@@ -4,7 +4,7 @@ import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import mods.eln.Eln;
-import mods.eln.achievepackets.AchievePacket;
+import mods.eln.packets.AchievePacket;
 import mods.eln.wiki.Root;
 import net.minecraftforge.client.event.GuiOpenEvent;
 

--- a/src/main/java/mods/eln/integration/waila/TransparentNodeHandler.kt
+++ b/src/main/java/mods/eln/integration/waila/TransparentNodeHandler.kt
@@ -35,8 +35,8 @@ class TransparentNodeHandler : IWailaDataProvider{
         } catch(e: Exception){
             //This is probably just it complaining about the cache returning null. Should be safe to ignore.
         }
-        for(entry: Map.Entry<String, String> in tipMap!!.asSequence()){
-            currenttip!! += (entry.key + ": " + SpecialChars.WHITE + entry.value)
+        for((key, value) in tipMap!!.asSequence()){
+            currenttip!! += (key + ": " + SpecialChars.WHITE + value)
         }
         return currenttip
     }

--- a/src/main/java/mods/eln/integration/waila/TransparentNodeHandler.kt
+++ b/src/main/java/mods/eln/integration/waila/TransparentNodeHandler.kt
@@ -1,0 +1,61 @@
+package mods.eln.integration.waila
+
+import cpw.mods.fml.common.Optional
+import mcp.mobius.waila.api.IWailaConfigHandler
+import mcp.mobius.waila.api.IWailaDataAccessor
+import mcp.mobius.waila.api.IWailaDataProvider
+import mcp.mobius.waila.api.SpecialChars
+import mods.eln.Eln
+import mods.eln.misc.Coordonate
+import mods.eln.packets.TransparentNodeRequestPacket
+import net.minecraft.client.Minecraft
+import net.minecraft.entity.player.EntityPlayerMP
+import net.minecraft.item.ItemStack
+import net.minecraft.nbt.NBTTagCompound
+import net.minecraft.tileentity.TileEntity
+import net.minecraft.world.World
+
+@Optional.Interface(iface = "mcp.mobius.waila.api.IWailaDataProvider", modid = "Waila")
+class TransparentNodeHandler : IWailaDataProvider{
+
+    companion object {
+        var updateTime = Minecraft.getSystemTime()
+    }
+
+    override fun getWailaBody(itemStack: ItemStack?, currenttip: MutableList<String>?, accessor: IWailaDataAccessor?, config: IWailaConfigHandler?): MutableList<String>? {
+        var tipMap: Map<String, String>? = mapOf()
+        val coord = accessor!!.position
+        val nodeCoord = Coordonate(coord.blockX, coord.blockY, coord.blockZ, accessor.world)
+        if(Minecraft.getSystemTime() - updateTime > 2000){
+            Eln.elnNetwork.sendToServer(TransparentNodeRequestPacket(Coordonate(nodeCoord)))
+            updateTime = Minecraft.getSystemTime()
+        }
+        try {
+            tipMap = WailaCache.nodes.get(nodeCoord)
+        } catch(e: Exception){
+            //This is probably just it complaining about the cache returning null. Should be safe to ignore.
+        }
+        for(entry: Map.Entry<String, String> in tipMap!!.asSequence()){
+            currenttip!! += (entry.key + ": " + SpecialChars.WHITE + entry.value)
+        }
+        return currenttip
+    }
+
+    override fun getWailaStack(accessor: IWailaDataAccessor?, config: IWailaConfigHandler?): ItemStack? {
+        return null
+    }
+
+    override fun getWailaTail(itemStack: ItemStack?, currenttip: MutableList<String>?, accessor: IWailaDataAccessor?, config: IWailaConfigHandler?): MutableList<String>? {
+        return currenttip
+    }
+
+    override fun getNBTData(player: EntityPlayerMP?, te: TileEntity?, tag: NBTTagCompound?, world: World?, x: Int, y: Int, z: Int): NBTTagCompound? {
+        return null
+    }
+
+    override fun getWailaHead(itemStack: ItemStack?, currenttip: MutableList<String>?, accessor: IWailaDataAccessor?, config: IWailaConfigHandler?): MutableList<String>? {
+        return currenttip
+    }
+
+
+}

--- a/src/main/java/mods/eln/integration/waila/WailaCache.java
+++ b/src/main/java/mods/eln/integration/waila/WailaCache.java
@@ -1,0 +1,29 @@
+package mods.eln.integration.waila;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import mods.eln.Eln;
+import mods.eln.misc.Coordonate;
+import mods.eln.packets.TransparentNodeRequestPacket;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Created by Gregory Maddra on 2016-06-29.
+ */
+public class WailaCache {
+
+    public static LoadingCache<Coordonate, Map<String, String>> nodes = CacheBuilder.newBuilder()
+            .maximumSize(1000)
+            .expireAfterWrite(1, TimeUnit.MINUTES)
+            .build(
+                    new CacheLoader<Coordonate, Map<String, String>>() {
+                        public Map<String, String> load(Coordonate key) throws Exception {
+                            Eln.elnNetwork.sendToServer(new TransparentNodeRequestPacket(key));
+                            return null;
+                        }
+                    }
+            );
+}

--- a/src/main/java/mods/eln/integration/waila/WailaIntegration.kt
+++ b/src/main/java/mods/eln/integration/waila/WailaIntegration.kt
@@ -1,0 +1,13 @@
+package mods.eln.integration.waila
+
+import cpw.mods.fml.common.Optional
+import mcp.mobius.waila.api.IWailaRegistrar
+
+@Optional.Interface(iface = "mcp.mobius.waila.api.IWailaRegistrar", modid = "Waila")
+object WailaIntegration {
+
+    @JvmStatic
+    fun callbackRegister(registrar: IWailaRegistrar){
+        registrar.registerBodyProvider(TransparentNodeHandler(), mods.eln.node.transparent.TransparentNodeBlock::class.java)
+    }
+}

--- a/src/main/java/mods/eln/mechanical/Flywheel.kt
+++ b/src/main/java/mods/eln/mechanical/Flywheel.kt
@@ -1,6 +1,7 @@
 package mods.eln.mechanical
 
 import mods.eln.misc.Obj3D
+import mods.eln.misc.Utils
 import mods.eln.node.transparent.EntityMetaTag
 import mods.eln.node.transparent.TransparentNode
 import mods.eln.node.transparent.TransparentNodeDescriptor
@@ -14,4 +15,11 @@ class FlywheelDescriptor(baseName : String, obj : Obj3D): SimpleShaftDescriptor(
 
 class FlyWheelElement(node : TransparentNode, desc_ : TransparentNodeDescriptor): StraightJointElement(node, desc_) {
     override val shaftMass = 100.0
+
+    override fun getWaila(): Map<String, String> {
+        var info = mutableMapOf<String, String>()
+        info.put("Speed", Utils.plotRads("", shaft.rads))
+        info.put("Energy", Utils.plotEnergy("", shaft.energy))
+        return info
+    }
 }

--- a/src/main/java/mods/eln/mechanical/Generator.kt
+++ b/src/main/java/mods/eln/mechanical/Generator.kt
@@ -273,4 +273,16 @@ class GeneratorElement(node: TransparentNode, desc_: TransparentNodeDescriptor):
         super.networkSerialize(stream)
         stream.writeDouble(lastE)
     }
+
+    override fun getWaila(): Map<String, String> {
+        var info = mutableMapOf<String, String>()
+        info.put("Energy", Utils.plotEnergy("", shaft.energy))
+        info.put("Speed", Utils.plotRads("", shaft.rads))
+        if(Eln.wailaEasyMode){
+            info.put("Voltage", Utils.plotVolt("", electricalPowerSource.getU()))
+            info.put("Current", Utils.plotAmpere("", electricalPowerSource.getI()))
+            info.put("Temperature", Utils.plotCelsius("", thermal.t))
+        }
+        return info
+    }
 }

--- a/src/main/java/mods/eln/mechanical/JointHub.kt
+++ b/src/main/java/mods/eln/mechanical/JointHub.kt
@@ -1,5 +1,6 @@
 package mods.eln.mechanical
 
+import mods.eln.Eln
 import mods.eln.cable.CableRenderDescriptor
 import mods.eln.misc.*
 import mods.eln.node.transparent.EntityMetaTag
@@ -102,6 +103,13 @@ class JointHubElement(node : TransparentNode, desc_ : TransparentNodeDescriptor)
     override fun readFromNBT(nbt: NBTTagCompound) {
         super.readFromNBT(nbt)
         connectedSides.readFromNBT(nbt, "connectedSides")
+    }
+
+    override fun getWaila(): Map<String, String> {
+        var info = mutableMapOf<String, String>()
+        info.put("Speed", Utils.plotRads("", shaft.rads))
+        info.put("Energy", Utils.plotEnergy("", shaft.energy))
+        return info
     }
 }
 

--- a/src/main/java/mods/eln/mechanical/StraightJoint.kt
+++ b/src/main/java/mods/eln/mechanical/StraightJoint.kt
@@ -3,6 +3,7 @@ package mods.eln.mechanical
 import mods.eln.misc.Direction
 import mods.eln.misc.LRDU
 import mods.eln.misc.Obj3D
+import mods.eln.misc.Utils
 import mods.eln.node.transparent.EntityMetaTag
 import mods.eln.node.transparent.TransparentNode
 import mods.eln.node.transparent.TransparentNodeDescriptor
@@ -30,4 +31,11 @@ open class StraightJointElement(node : TransparentNode, desc_ : TransparentNodeD
 
     override fun onBlockActivated(entityPlayer: EntityPlayer?, side: Direction?, vx: Float, vy: Float,
                                   vz: Float): Boolean = false
+
+    override fun getWaila(): Map<String, String> {
+        var info = mutableMapOf<String, String>()
+        info.put("Speed", Utils.plotRads("", shaft.rads))
+        info.put("Energy", Utils.plotEnergy("", shaft.energy))
+        return info
+    }
 }

--- a/src/main/java/mods/eln/mechanical/Tachometer.kt
+++ b/src/main/java/mods/eln/mechanical/Tachometer.kt
@@ -111,6 +111,10 @@ open class TachometerElement(node : TransparentNode, desc_ : TransparentNodeDesc
         nbt.setFloat("minRads", minRads)
         nbt.setFloat("maxRads", maxRads)
     }
+
+    override fun getWaila(): Map<String, String> {
+        return mapOf()
+    }
 }
 
 class TachometerRender(entity: TransparentNodeEntity, desc: TransparentNodeDescriptor): ShaftRender(entity, desc) {

--- a/src/main/java/mods/eln/mechanical/Turbines.kt
+++ b/src/main/java/mods/eln/mechanical/Turbines.kt
@@ -179,6 +179,17 @@ class TurbineElement(node : TransparentNode, desc_ : TransparentNodeDescriptor) 
         tank.readFromNBT(nbt, "tank")
         turbineSlowProcess.readFromNBT(nbt, "proc")
     }
+
+    override fun getWaila(): Map<String, String> {
+        var info = mutableMapOf<String, String>()
+        info.put("Speed", Utils.plotRads("", shaft.rads))
+        info.put("Energy", Utils.plotEnergy("", shaft.energy))
+        if(Eln.wailaEasyMode){
+            info.put("Efficency", Utils.plotPercent("", efficiency.toDouble()))
+            info.put("Fuel usage", Utils.plotBuckets("", steamRate/1000.0) + "/s")
+        }
+        return info
+    }
 }
 
 class TurbineRender(entity: TransparentNodeEntity, desc: TransparentNodeDescriptor): ShaftRender(entity, desc) {

--- a/src/main/java/mods/eln/misc/Utils.java
+++ b/src/main/java/mods/eln/misc/Utils.java
@@ -1113,6 +1113,23 @@ public class Utils {
 		return 0;
 	}
 
+	public static <T> double readPrivateDouble(Object o, String feildName) {
+		try {
+			Field f = o.getClass().getDeclaredField(feildName);
+			f.setAccessible(true);
+			return f.getDouble(o);
+		} catch (IllegalArgumentException e) {
+			e.printStackTrace();
+		} catch (SecurityException e) {
+			e.printStackTrace();
+		} catch (IllegalAccessException e) {
+			e.printStackTrace();
+		} catch (NoSuchFieldException e) {
+			e.printStackTrace();
+		}
+		return 0;
+	}
+
 	public static ItemStack[][] getItemStackGrid(IRecipe r) {
 		ItemStack[][] stacks = new ItemStack[3][3];
 		try {

--- a/src/main/java/mods/eln/misc/Utils.java
+++ b/src/main/java/mods/eln/misc/Utils.java
@@ -337,6 +337,12 @@ public class Utils {
 		return header + plotTime(value);
 	}
 
+	public static String plotBuckets(String header, double buckets) {
+		if (!header.equals(""))
+			header += " ";
+		return header + plotValue(buckets, "B ");
+	}
+
 	public static void readFromNBT(NBTTagCompound nbt, String str, IInventory inventory) {
 		NBTTagList var2 = nbt.getTagList(str, 10);
 

--- a/src/main/java/mods/eln/node/transparent/TransparentNodeElement.java
+++ b/src/main/java/mods/eln/node/transparent/TransparentNodeElement.java
@@ -29,6 +29,8 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 public abstract class TransparentNodeElement implements  GhostObserver, IPlayer, Publishable {
 
@@ -506,4 +508,10 @@ public abstract class TransparentNodeElement implements  GhostObserver, IPlayer,
 		return hasSidedInventory() ? 0x4 : 0;
 	}
 	*/
+
+	public Map<String, String> getWaila(){
+		Map<String, String> wailaList = new HashMap<String, String>();
+		wailaList.put("Info", multiMeterString(this.front));
+		return wailaList;
+	}
 }

--- a/src/main/java/mods/eln/packets/AchievePacket.java
+++ b/src/main/java/mods/eln/packets/AchievePacket.java
@@ -1,4 +1,4 @@
-package mods.eln.achievepackets;
+package mods.eln.packets;
 
 import io.netty.buffer.ByteBuf;
 import cpw.mods.fml.common.network.ByteBufUtils;

--- a/src/main/java/mods/eln/packets/AchievePacketHandler.java
+++ b/src/main/java/mods/eln/packets/AchievePacketHandler.java
@@ -1,4 +1,4 @@
-package mods.eln.achievepackets;
+package mods.eln.packets;
 
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;

--- a/src/main/java/mods/eln/packets/NodeReturnPacket.kt
+++ b/src/main/java/mods/eln/packets/NodeReturnPacket.kt
@@ -1,0 +1,63 @@
+package mods.eln.packets
+
+import cpw.mods.fml.common.network.ByteBufUtils
+import cpw.mods.fml.common.network.simpleimpl.IMessage
+import io.netty.buffer.ByteBuf
+import mods.eln.misc.Coordonate
+import java.util.*
+
+/**
+ * Created by Gregory Maddra on 2016-06-27.
+ */
+class NodeReturnPacket : IMessage{
+
+    lateinit var map: Map<String, String>
+    lateinit var coord: Coordonate
+
+    constructor(){
+
+    }
+
+    constructor(m: Map<String, String>, c: Coordonate){
+        map = m
+        coord = c
+    }
+
+    override fun fromBytes(buf: ByteBuf?) {
+        var keys = listOf<String>()
+        var values = listOf<String>()
+        val length1 = ByteBufUtils.readVarInt(buf, 5)
+        for(i in 1..length1){
+            keys += ByteBufUtils.readUTF8String(buf)
+        }
+        for(k in 1..length1){
+            values += ByteBufUtils.readUTF8String(buf)
+        }
+        val x = ByteBufUtils.readVarInt(buf, 5)
+        val y = ByteBufUtils.readVarInt(buf, 5)
+        val z = ByteBufUtils.readVarInt(buf, 5)
+        val w = ByteBufUtils.readVarInt(buf, 5)
+        coord = Coordonate(x, y, z, w)
+        val i1 = keys.iterator()
+        val i2 = values.iterator()
+        var localmap = HashMap<String, String>()
+        while (i1.hasNext() && i2.hasNext()){
+            localmap.put(i1.next(), i2.next())
+        }
+        map = localmap
+    }
+
+    override fun toBytes(buf: ByteBuf?) {
+        ByteBufUtils.writeVarInt(buf, map.size, 5)
+        for(element: String in map.keys.iterator()){
+            ByteBufUtils.writeUTF8String(buf, element)
+        }
+        for(element: String in map.values.iterator()){
+            ByteBufUtils.writeUTF8String(buf, element)
+        }
+        ByteBufUtils.writeVarInt(buf, coord.x, 5)
+        ByteBufUtils.writeVarInt(buf, coord.y, 5)
+        ByteBufUtils.writeVarInt(buf, coord.z, 5)
+        ByteBufUtils.writeVarInt(buf, coord.dimention, 5)
+    }
+}

--- a/src/main/java/mods/eln/packets/NodeReturnPacketHandler.kt
+++ b/src/main/java/mods/eln/packets/NodeReturnPacketHandler.kt
@@ -1,0 +1,18 @@
+package mods.eln.packets
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler
+import cpw.mods.fml.common.network.simpleimpl.MessageContext
+import mods.eln.integration.waila.WailaCache
+
+/**
+ * Created by Gregory Maddra on 2016-06-27.
+ */
+class NodeReturnPacketHandler : IMessageHandler<NodeReturnPacket, IMessage> {
+    override fun onMessage(message: NodeReturnPacket?, ctx: MessageContext?): IMessage? {
+        val map = message!!.map
+        val coord = message.coord
+        WailaCache.nodes.put(coord, map)
+        return null
+    }
+}

--- a/src/main/java/mods/eln/packets/TransparentNodeRequestPacket.kt
+++ b/src/main/java/mods/eln/packets/TransparentNodeRequestPacket.kt
@@ -1,0 +1,37 @@
+package mods.eln.packets
+
+import cpw.mods.fml.common.network.ByteBufUtils
+import cpw.mods.fml.common.network.simpleimpl.IMessage
+import io.netty.buffer.ByteBuf
+import mods.eln.misc.Coordonate
+
+/**
+ * Created by Gregory Maddra on 2016-06-27.
+ */
+class TransparentNodeRequestPacket : IMessage{
+
+    lateinit var coord: Coordonate
+
+    constructor(){
+
+    }
+
+    constructor(c: Coordonate){
+        coord = c
+    }
+
+    override fun fromBytes(buf: ByteBuf?) {
+        val x = ByteBufUtils.readVarInt(buf, 5)
+        val y = ByteBufUtils.readVarInt(buf, 5)
+        val z = ByteBufUtils.readVarInt(buf, 5)
+        val w = ByteBufUtils.readVarInt(buf, 5)
+        coord = Coordonate(x, y, z, w)
+    }
+
+    override fun toBytes(buf: ByteBuf?) {
+        ByteBufUtils.writeVarInt(buf, coord.x, 5)
+        ByteBufUtils.writeVarInt(buf, coord.y, 5)
+        ByteBufUtils.writeVarInt(buf, coord.z, 5)
+        ByteBufUtils.writeVarInt(buf, coord.dimention, 5)
+    }
+}

--- a/src/main/java/mods/eln/packets/TransparentNodeRequestPacketHandler.kt
+++ b/src/main/java/mods/eln/packets/TransparentNodeRequestPacketHandler.kt
@@ -1,0 +1,33 @@
+package mods.eln.packets
+
+import cpw.mods.fml.common.FMLLog
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler
+import cpw.mods.fml.common.network.simpleimpl.MessageContext
+import mods.eln.node.NodeManager
+import mods.eln.node.transparent.TransparentNode
+import net.minecraft.nbt.NBTTagCompound
+
+/**
+ * Created by Gregory Maddra on 2016-06-27.
+ */
+class TransparentNodeRequestPacketHandler : IMessageHandler<TransparentNodeRequestPacket, NodeReturnPacket> {
+
+    companion object{
+        var nodeData = NBTTagCompound()
+    }
+
+    override fun onMessage(message: TransparentNodeRequestPacket?, ctx: MessageContext?): NodeReturnPacket? {
+        val c = message!!.coord
+        val node = NodeManager.instance.getNodeFromCoordonate(c) as TransparentNode
+        var stringMap: Map<String, String>
+        try {
+            stringMap = node.element.waila
+        } catch (e: NullPointerException){
+            FMLLog.getLogger().warn("Attempted to get WAILA info for an invalid node!")
+            e.printStackTrace()
+            return null
+        }
+        return NodeReturnPacket(stringMap, c)
+    }
+
+}

--- a/src/main/java/mods/eln/transparentnode/FuelGenerator.kt
+++ b/src/main/java/mods/eln/transparentnode/FuelGenerator.kt
@@ -26,6 +26,7 @@ import net.minecraftforge.fluids.FluidRegistry
 import org.lwjgl.opengl.GL11
 import java.io.DataInputStream
 import java.io.DataOutputStream
+import java.text.DecimalFormat
 
 class FuelGeneratorDescriptor(name: String, internal val obj: Obj3D?, internal val cable: ElectricalCableDescriptor,
                               internal val nominalPower: Double, internal val maxVoltage: Double,
@@ -218,6 +219,14 @@ class FuelGeneratorElement(transparentNode: TransparentNode, descriptor_: Transp
         super.writeToNBT(nbt)
         nbt?.setDouble("tankLevel", tankLevel)
         nbt?.setBoolean("on", on)
+    }
+
+    override fun getWaila(): Map<String,String>{
+        var info = mutableMapOf<String,String>()
+        val format = DecimalFormat("#.##")
+        info.put("Fuel level", Utils.plotPercent("", tankLevel))
+        info.put("Voltage", format.format(positiveLoad.u) + "v")
+        return info
     }
 }
 

--- a/src/main/java/mods/eln/transparentnode/LargeRheostat.kt
+++ b/src/main/java/mods/eln/transparentnode/LargeRheostat.kt
@@ -174,6 +174,12 @@ class LargeRheostatElement(node: TransparentNode, desc_: TransparentNodeDescript
     override fun getInventory() = inventory
     override fun onBlockActivated(entityPlayer: EntityPlayer?, side: Direction?, vx: Float, vy: Float, vz: Float) = false
     override fun newContainer(side: Direction?, player: EntityPlayer?) = ResistorContainer(player, inventory)
+
+    override fun getWaila(): Map<String, String> {
+        var info = mutableMapOf<String, String>()
+        info.put("Resistance", Utils.plotValue(resistor.r, "\u03A9"))
+        return info
+    }
 }
 
 class LargeRheostatRender(entity: TransparentNodeEntity, desc: TransparentNodeDescriptor) :
@@ -225,6 +231,7 @@ class LargeRheostatRender(entity: TransparentNodeEntity, desc: TransparentNodeDe
     override fun newGuiDraw(side: Direction, player: EntityPlayer): GuiScreen {
         return LargeRheostatGUI(player, inventory, this)
     }
+
 }
 
 class LargeRheostatGUI(player: EntityPlayer, inventory: IInventory, internal var render: LargeRheostatRender) :

--- a/src/main/java/mods/eln/transparentnode/autominer/AutoMinerElement.java
+++ b/src/main/java/mods/eln/transparentnode/autominer/AutoMinerElement.java
@@ -4,6 +4,8 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 import mods.eln.misc.Coordonate;
 import mods.eln.misc.Direction;
@@ -206,5 +208,14 @@ public class AutoMinerElement extends TransparentNodeElement  {
 				return packetType;
 		}
 		return unserializeNulldId;
+	}
+
+	@Override
+	public Map<String, String> getWaila(){
+		//Why are you even looking at this part of the machine... it's literally the part the drill comes out of.
+		Map<String, String> info = new HashMap<String, String>();
+		info.put("Silk Touch", slowProcess.silkTouch ? "Yes" : "No");
+		info.put("Depth", Utils.plotValue(slowProcess.pipeLength, "m "));
+		return info;
 	}
 }

--- a/src/main/java/mods/eln/transparentnode/battery/BatteryElement.java
+++ b/src/main/java/mods/eln/transparentnode/battery/BatteryElement.java
@@ -1,5 +1,6 @@
 package mods.eln.transparentnode.battery;
 
+import mods.eln.Eln;
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
 import mods.eln.misc.Utils;
@@ -24,6 +25,9 @@ import net.minecraft.nbt.NBTTagCompound;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.text.DecimalFormat;
+import java.util.HashMap;
+import java.util.Map;
 
 public class BatteryElement extends TransparentNodeElement {
 
@@ -246,4 +250,25 @@ public class BatteryElement extends TransparentNodeElement {
 		nbt.setDouble("life", 1.0);
 		return nbt;
 	}*/
+
+	@Override
+	public Map<String, String> getWaila() {
+		Map<String, String> wailaList = new HashMap<String, String>();
+		DecimalFormat df = new DecimalFormat("#.##");
+		String charge, energy, life, voltage, current = "";
+		NbtBatteryProcess p = batteryProcess;
+		charge = df.format(p.getCharge() * 100.0) + "%";
+		energy = df.format(p.getEnergy() / 1000.0) + "kJ";
+		life = df.format(p.life * 100.0) + "%";
+		voltage = df.format(p.getU()) + "v";
+		current = df.format(p.getDischargeCurrent())+"a";
+		wailaList.put("Charge", charge);
+		wailaList.put("Energy", energy);
+		wailaList.put("Life", life);
+		if(Eln.wailaEasyMode){
+			wailaList.put("Voltage", voltage);
+			wailaList.put("Current", current);
+		}
+		return wailaList;
+	}
 }

--- a/src/main/java/mods/eln/transparentnode/computercraftio/ComputerCraftIoElement.java
+++ b/src/main/java/mods/eln/transparentnode/computercraftio/ComputerCraftIoElement.java
@@ -18,6 +18,8 @@ import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.api.peripheral.IPeripheral;
 
+import java.util.Map;
+
 public class ComputerCraftIoElement extends TransparentNodeElement implements IPeripheral {
 	
 	public NbtElectricalGateInputOutput[] ioGate = new NbtElectricalGateInputOutput[4];
@@ -159,5 +161,10 @@ public class ComputerCraftIoElement extends TransparentNodeElement implements IP
 	@Override
 	public boolean equals(IPeripheral other) {
 		return other == this;
-	}    
+	}
+
+	@Override
+	public Map<String, String> getWaila() {
+		return null;
+	}
 }

--- a/src/main/java/mods/eln/transparentnode/eggincubator/EggIncubatorElement.java
+++ b/src/main/java/mods/eln/transparentnode/eggincubator/EggIncubatorElement.java
@@ -2,6 +2,8 @@ package mods.eln.transparentnode.eggincubator;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import mods.eln.misc.Direction;
 import mods.eln.misc.INBTTReady;
@@ -175,5 +177,13 @@ public class EggIncubatorElement extends TransparentNodeElement {
 			e.printStackTrace();
 		}
 		lastVoltagePublish = powerLoad.getU();
+	}
+
+	@Override
+	public Map<String, String> getWaila(){
+		Map<String, String> info = new HashMap<String, String>();
+		//This feels a bit hacky. Maybe there's a better way?
+		info.put("Has Egg", powerResistor.getR() == descriptor.Rp ? "Yes" : "No");
+		return info;
 	}
 }

--- a/src/main/java/mods/eln/transparentnode/electricalantennarx/ElectricalAntennaRxElement.java
+++ b/src/main/java/mods/eln/transparentnode/electricalantennarx/ElectricalAntennaRxElement.java
@@ -1,7 +1,10 @@
 package mods.eln.transparentnode.electricalantennarx;
 
 import java.io.DataOutputStream;
+import java.util.HashMap;
+import java.util.Map;
 
+import mods.eln.Eln;
 import mods.eln.misc.Coordonate;
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
@@ -140,5 +143,15 @@ public class ElectricalAntennaRxElement extends TransparentNodeElement {
 		super.networkSerialize(stream);
 		rot.serialize(stream);		
 		node.lrduCubeMask.getTranslate(front.getInverse()).serialize(stream);
+	}
+
+	public Map<String, String> getWaila() {
+		Map<String, String> info = new HashMap<String, String>();
+		info.put("Receiving", powerSrc.getP() != 0 ? "Yes" : "No");
+		if(Eln.wailaEasyMode){
+			info.put("Power Received", Utils.plotPower("", powerSrc.getP()));
+			info.put("Effective Power", Utils.plotPower("", powerSrc.getEffectiveP()));
+		}
+		return info;
 	}
 }

--- a/src/main/java/mods/eln/transparentnode/electricalantennatx/ElectricalAntennaTxElement.java
+++ b/src/main/java/mods/eln/transparentnode/electricalantennatx/ElectricalAntennaTxElement.java
@@ -1,7 +1,10 @@
 package mods.eln.transparentnode.electricalantennatx;
 
 import java.io.DataOutputStream;
+import java.util.HashMap;
+import java.util.Map;
 
+import mods.eln.Eln;
 import mods.eln.misc.Coordonate;
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
@@ -193,5 +196,16 @@ public class ElectricalAntennaTxElement extends TransparentNodeElement{
 		super.networkSerialize(stream);
 		rot.serialize(stream);
 		node.lrduCubeMask.getTranslate(front.getInverse()).serialize(stream);
+	}
+
+	@Override
+	public Map<String, String> getWaila() {
+		Map<String, String> info = new HashMap<String, String>();
+		info.put("Transmitting", commandIn.getNormalized() > 0 ? "Yes" : "No");
+		info.put("Efficency", Utils.plotPercent("", powerEfficency));
+		if (Eln.wailaEasyMode) {
+			info.put("Power", Utils.plotPower("", powerIn.getI() * powerIn.getU()));
+		}
+		return info;
 	}
 }

--- a/src/main/java/mods/eln/transparentnode/electricalfurnace/ElectricalFurnaceElement.java
+++ b/src/main/java/mods/eln/transparentnode/electricalfurnace/ElectricalFurnaceElement.java
@@ -2,6 +2,7 @@ package mods.eln.transparentnode.electricalfurnace;
 
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.util.*;
 
 import mods.eln.Eln;
 import mods.eln.generic.GenericItemUsingDamage;
@@ -257,5 +258,15 @@ public class ElectricalFurnaceElement extends TransparentNodeElement {
 			e.printStackTrace();
 		}
 		return unserializeNulldId;
+	}
+
+	@Override
+	public Map<String, String> getWaila(){
+		Map<String, String> info = new HashMap<String, String>();
+		info.put("Temperature", Utils.plotCelsius("", thermalLoad.Tc));
+		if(inventory.getStackInSlot(heatingCorpSlotId) != null) {
+			info.put("Heating Element", inventory.getStackInSlot(heatingCorpSlotId).getDisplayName());
+		}
+		return info;
 	}
 }

--- a/src/main/java/mods/eln/transparentnode/electricalmachine/ElectricalMachineElement.java
+++ b/src/main/java/mods/eln/transparentnode/electricalmachine/ElectricalMachineElement.java
@@ -1,7 +1,11 @@
 package mods.eln.transparentnode.electricalmachine;
 
 import java.io.IOException;
+import java.text.DecimalFormat;
+import java.util.HashMap;
+import java.util.Map;
 
+import mods.eln.Eln;
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
 import mods.eln.misc.Utils;
@@ -185,5 +189,17 @@ public class ElectricalMachineElement extends TransparentNodeElement implements 
 		needPublish();
 		if (descriptor.endSound != null)
 			play(descriptor.endSound);
+	}
+
+	@Override
+	public Map<String, String> getWaila(){
+		Map<String, String> info = new HashMap<String, String>();
+		DecimalFormat format = new DecimalFormat("#.##");
+		info.put("Power Used", Utils.plotPower("", slowRefreshProcess.getPower()));
+		info.put("Voltage", Utils.plotVolt("", electricalLoad.getU()));
+		if(Eln.wailaEasyMode) {
+			info.put("Power Provided", Utils.plotPower("", electricalLoad.getI() * electricalLoad.getU()));
+		}
+		return info;
 	}
 }

--- a/src/main/java/mods/eln/transparentnode/heatfurnace/HeatFurnaceElement.java
+++ b/src/main/java/mods/eln/transparentnode/heatfurnace/HeatFurnaceElement.java
@@ -3,6 +3,9 @@ package mods.eln.transparentnode.heatfurnace;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.text.DecimalFormat;
+import java.util.HashMap;
+import java.util.Map;
 
 import mods.eln.item.regulator.IRegulatorDescriptor;
 import mods.eln.misc.Direction;
@@ -237,5 +240,14 @@ public class HeatFurnaceElement extends TransparentNodeElement {
 		super.readFromNBT(nbt);
 		takeFuel = nbt.getBoolean("takeFuel");
 		controlExternal = nbt.getBoolean("controlExternal");
+	}
+
+	@Override
+	public Map<String, String> getWaila(){
+		Map<String, String> info = new HashMap<String, String>();
+		DecimalFormat format = new DecimalFormat("#.#");
+		info.put("Temperature", Utils.plotCelsius("", thermalLoad.Tc));
+		info.put("Target Temp", Utils.plotCelsius("", regulator.getTarget()));
+		return info;
 	}
 }

--- a/src/main/java/mods/eln/transparentnode/solarpanel/SolarPanelElement.java
+++ b/src/main/java/mods/eln/transparentnode/solarpanel/SolarPanelElement.java
@@ -2,6 +2,9 @@ package mods.eln.transparentnode.solarpanel;
 
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.text.DecimalFormat;
+import java.util.HashMap;
+import java.util.Map;
 
 import mods.eln.Eln;
 import mods.eln.misc.Direction;
@@ -196,6 +199,16 @@ public class SolarPanelElement extends TransparentNodeElement{
 	@Override
 	public Container newContainer(Direction side, EntityPlayer player) {
 		return new SolarPanelContainer(node, player, inventory);
+	}
+
+	@Override
+	public Map<String, String> getWaila(){
+		Map<String, String> info = new HashMap<String, String>();
+		DecimalFormat format = new DecimalFormat("#.##");
+		info.put("Sun Angle", format.format(((slowProcess.getSolarAlpha()) * (180/Math.PI)) - 90) + "\u00B0");
+		info.put("Panel Angle", format.format((pannelAlpha * (180/Math.PI)) - 90) + "\u00B0");
+		info.put("Light", (slowProcess.getSolarLight() != 0 ? "Yes" : "No"));
+		return info;
 	}
 	
 }

--- a/src/main/java/mods/eln/transparentnode/teleporter/TeleporterElement.java
+++ b/src/main/java/mods/eln/transparentnode/teleporter/TeleporterElement.java
@@ -3,8 +3,11 @@ package mods.eln.transparentnode.teleporter;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.text.DecimalFormat;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import mods.eln.misc.Coordonate;
 import mods.eln.misc.Direction;
@@ -623,5 +626,16 @@ public class TeleporterElement extends TransparentNodeElement implements ITelepo
 	public String getName() {
 
 		return name;
+	}
+
+	@Override
+	public Map<String, String> getWaila(){
+		Map<String, String> info = new HashMap<String, String>();
+		DecimalFormat format = new DecimalFormat("#.##");
+		info.put("Destination", targetName);
+		info.put("Distance", format.format(getTeleportCoordonate().trueDistanceTo(getTarget(targetName).getTeleportCoordonate())) + "m");
+		info.put("Power required", format.format(energyTarget) + "J");
+		info.put("Charge rate", powerCharge + "W");
+		return info;
 	}
 }

--- a/src/main/java/mods/eln/transparentnode/thermaldissipatoractive/ThermalDissipatorActiveElement.java
+++ b/src/main/java/mods/eln/transparentnode/thermaldissipatoractive/ThermalDissipatorActiveElement.java
@@ -2,7 +2,10 @@ package mods.eln.transparentnode.thermaldissipatoractive;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
+import mods.eln.Eln;
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
 import mods.eln.misc.Utils;
@@ -118,7 +121,15 @@ public class ThermalDissipatorActiveElement extends TransparentNodeElement{
 	}
 	public float lastPowerFactor;
 	
-	
+	@Override
+	public Map<String, String> getWaila() {
+		Map<String, String> info = new HashMap<String, String>();
+		if(Eln.wailaEasyMode){
+			info.put("Temperature", Utils.plotCelsius("", thermalLoad.Tc));
+			info.put("Thermal Power", Utils.plotPower("", thermalLoad.getPower()));
+		}
+		return info;
+	}
 
 
 }

--- a/src/main/java/mods/eln/transparentnode/thermaldissipatorpassive/ThermalDissipatorPassiveElement.java
+++ b/src/main/java/mods/eln/transparentnode/thermaldissipatorpassive/ThermalDissipatorPassiveElement.java
@@ -2,6 +2,7 @@ package mods.eln.transparentnode.thermaldissipatorpassive;
 
 
 
+import mods.eln.Eln;
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
 import mods.eln.misc.Utils;
@@ -18,6 +19,9 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class ThermalDissipatorPassiveElement extends TransparentNodeElement{
 	ThermalDissipatorPassiveDescriptor descriptor;
@@ -103,6 +107,16 @@ public class ThermalDissipatorPassiveElement extends TransparentNodeElement{
 			return true;
 		}
 		return false;
+	}
+
+	@Override
+	public Map<String, String> getWaila() {
+		Map<String, String> info = new HashMap<String, String>();
+		if(Eln.wailaEasyMode){
+			info.put("Temperature", Utils.plotCelsius("", thermalLoad.Tc));
+			info.put("Thermal Power", Utils.plotPower("", thermalLoad.getPower()));
+		}
+		return info;
 	}
 
 }

--- a/src/main/java/mods/eln/transparentnode/transformer/TransformerElement.java
+++ b/src/main/java/mods/eln/transparentnode/transformer/TransformerElement.java
@@ -1,16 +1,15 @@
 package mods.eln.transparentnode.transformer;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-
 import mods.eln.Eln;
 import mods.eln.item.FerromagneticCoreDescriptor;
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
 import mods.eln.misc.Utils;
 import mods.eln.node.NodeBase;
-import mods.eln.node.transparent.*;
+import mods.eln.node.transparent.TransparentNode;
+import mods.eln.node.transparent.TransparentNodeDescriptor;
+import mods.eln.node.transparent.TransparentNodeElement;
+import mods.eln.node.transparent.TransparentNodeElementInventory;
 import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.mna.component.Transformer;
@@ -27,6 +26,13 @@ import net.minecraft.inventory.Container;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.text.DecimalFormat;
+import java.util.HashMap;
+import java.util.Map;
 
 public class TransformerElement extends TransparentNodeElement {
 	public NbtElectricalLoad primaryLoad = new NbtElectricalLoad("primaryLoad");
@@ -329,5 +335,22 @@ public class TransformerElement extends TransparentNodeElement {
 	public void readFromNBT(NBTTagCompound nbt) {
 		super.readFromNBT(nbt);
 		isIsolator = nbt.getBoolean("isIsolated");
+	}
+
+	@Override
+	public Map<String, String> getWaila(){
+		Map<String, String> info = new HashMap<String, String>();
+		DecimalFormat format = new DecimalFormat("#.##");
+		info.put("Ratio", format.format(Utils.readPrivateDouble(transformer, "ratio")));
+		FerromagneticCoreDescriptor core = (FerromagneticCoreDescriptor) FerromagneticCoreDescriptor.getDescriptor(inventory.getStackInSlot(TransformerContainer.ferromagneticSlotId));
+		if(core != null){
+			info.put("Core Factor", format.format(core.cableMultiplicator));
+		}
+		info.put("Isolated", isIsolator ? "Yes" : "No");
+		if(Eln.wailaEasyMode){
+			info.put("Voltage+", Utils.plotVolt("", primaryLoad.getU()));
+			info.put("Voltage-", Utils.plotVolt("", secondaryLoad.getU()));
+		}
+		return info;
 	}
 }

--- a/src/main/java/mods/eln/transparentnode/turbine/TurbineElement.java
+++ b/src/main/java/mods/eln/transparentnode/turbine/TurbineElement.java
@@ -1,6 +1,8 @@
 package mods.eln.transparentnode.turbine;
 
 import java.io.DataOutputStream;
+import java.util.HashMap;
+import java.util.Map;
 
 import mods.eln.Eln;
 import mods.eln.misc.Direction;
@@ -206,5 +208,15 @@ public class TurbineElement extends TransparentNodeElement{
 		
 		super.networkSerialize(stream);
 		node.lrduCubeMask.getTranslate(front.down()).serialize(stream);
+	}
+
+	@Override
+	public Map<String, String> getWaila(){
+		Map<String, String> info = new HashMap<String, String>();
+		info.put("Nominal \u0394T", (warmLoad.Tc - coolLoad.Tc == descriptor.nominalDeltaT ? "Yes" : "No"));
+		if(Eln.wailaEasyMode){
+			info.put("\u0394T", Utils.plotCelsius("", warmLoad.Tc - coolLoad.Tc));
+		}
+		return info;
 	}
 }

--- a/src/main/java/mods/eln/transparentnode/turret/TurretElement.java
+++ b/src/main/java/mods/eln/transparentnode/turret/TurretElement.java
@@ -23,6 +23,8 @@ import net.minecraft.nbt.NBTTagCompound;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class TurretElement extends TransparentNodeElement {
 
@@ -215,8 +217,17 @@ public class TurretElement extends TransparentNodeElement {
             }
         } catch (IOException e) {
 
+
+
             e.printStackTrace();
         }
         return unserializeNulldId;
     }
+
+	@Override
+	public Map<String, String> getWaila(){
+		Map<String, String> info = new HashMap<String, String>();
+		info.put("Charge Rate", Utils.plotPower("", chargePower));
+		return info;
+	}
 }

--- a/src/main/java/mods/eln/transparentnode/waterturbine/WaterTurbineElement.java
+++ b/src/main/java/mods/eln/transparentnode/waterturbine/WaterTurbineElement.java
@@ -2,6 +2,9 @@ package mods.eln.transparentnode.waterturbine;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.text.DecimalFormat;
+import java.util.HashMap;
+import java.util.Map;
 
 import mods.eln.misc.Coordonate;
 import mods.eln.misc.Direction;
@@ -138,7 +141,13 @@ public class WaterTurbineElement extends TransparentNodeElement{
 	}
 
 
-	
+	@Override
+	public Map<String, String> getWaila(){
+		Map<String, String> wailaList = new HashMap<String, String>();
+		DecimalFormat format = new DecimalFormat("#.##");
+		wailaList.put("Voltage", format.format(positiveLoad.getU()));
+		return wailaList;
+	}
 	
 	 
 

--- a/src/main/java/mods/eln/transparentnode/windturbine/WindTurbineElement.java
+++ b/src/main/java/mods/eln/transparentnode/windturbine/WindTurbineElement.java
@@ -17,6 +17,9 @@ import net.minecraft.nbt.NBTTagCompound;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.text.DecimalFormat;
+import java.util.HashMap;
+import java.util.Map;
 
 public class WindTurbineElement extends TransparentNodeElement {
     private final NbtElectricalLoad positiveLoad = new NbtElectricalLoad("positiveLoad");
@@ -111,5 +114,13 @@ public class WindTurbineElement extends TransparentNodeElement {
         super.readFromNBT(nbt);
         cableFront = Direction.readFromNBT(nbt, "cableFront");
         Utils.println(cableFront);
+    }
+
+    @Override
+    public Map<String, String> getWaila(){
+        Map<String, String> wailaList = new HashMap<String, String>();
+        DecimalFormat format = new DecimalFormat("#.##");
+        wailaList.put("Voltage", format.format(getElectricalLoad(cableFront.left(), LRDU.Down).getU()));
+        return wailaList;
     }
 }


### PR DESCRIPTION
Adds WAILA support for all transparent nodes. Includes a configurable "Easy Mode" that shows more info on a few devices.

Also adds a plotBuckets and a readPrivateDouble function to Utils.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/electrical-age/electricalage/480)

<!-- Reviewable:end -->
