### PR TITLE
Waila for ghost blocks of sixnode blocks

### DIFF
--- a/src/main/java/mods/eln/integration/waila/GhostNodeWailaData.kt
+++ b/src/main/java/mods/eln/integration/waila/GhostNodeWailaData.kt
@@ -1,6 +1,9 @@
 package mods.eln.integration.waila
 
 import mods.eln.misc.Coordonate
+import mods.eln.packets.GhostNodeWailaResponsePacket
 import net.minecraft.item.ItemStack
 
-data class GhostNodeWailaData(val realCoord: Coordonate, val itemStack: ItemStack?)
+data class GhostNodeWailaData(val realCoord: Coordonate,
+                              val itemStack: ItemStack?,
+                              val type: Byte = GhostNodeWailaResponsePacket.UNKNOWN_TYPE)

--- a/src/main/java/mods/eln/integration/waila/GhostNodeWailaProvider.kt
+++ b/src/main/java/mods/eln/integration/waila/GhostNodeWailaProvider.kt
@@ -8,6 +8,7 @@ import mcp.mobius.waila.api.IWailaDataProvider
 import mods.eln.Eln
 import mods.eln.misc.Coordonate
 import mods.eln.packets.GhostNodeWailaRequestPacket
+import mods.eln.packets.GhostNodeWailaResponsePacket
 import net.minecraft.client.Minecraft
 import net.minecraft.entity.player.EntityPlayerMP
 import net.minecraft.item.ItemStack
@@ -58,9 +59,14 @@ class GhostNodeWailaProvider(private val transparentNodeHandler: TransparentNode
 
     override fun getWailaBody(itemStack: ItemStack?, currenttip: MutableList<String>?, accessor: IWailaDataAccessor,
                               config: IWailaConfigHandler?): MutableList<String>? {
-        val realCoord = getGhostData(accessor)?.realCoord
-        return if (realCoord != null) {
-            transparentNodeHandler.getWailaBody(itemStack, currenttip, WailaDataAccessorProxy(accessor, realCoord), config)
+        val ghostData = getGhostData(accessor)
+        val realCoord = ghostData?.realCoord
+        return if (ghostData != null && realCoord != null) {
+            return when (ghostData.type) {
+                GhostNodeWailaResponsePacket.TRANSPARENT_BLOCK_TYPE -> transparentNodeHandler.getWailaBody(itemStack, currenttip, WailaDataAccessorProxy(accessor, realCoord), config)
+                GhostNodeWailaResponsePacket.SIXNODE_TYPE -> currenttip // TODO:...
+                else -> currenttip
+            }
         } else {
             currenttip
         }

--- a/src/main/java/mods/eln/packets/GhostNodeWailaRequestPacketHandler.kt
+++ b/src/main/java/mods/eln/packets/GhostNodeWailaRequestPacketHandler.kt
@@ -5,6 +5,7 @@ import cpw.mods.fml.common.network.simpleimpl.MessageContext
 import mods.eln.Eln
 import mods.eln.misc.Coordonate
 import mods.eln.node.NodeManager
+import mods.eln.node.six.SixNode
 import mods.eln.node.transparent.TransparentNode
 import net.minecraft.item.ItemStack
 
@@ -12,14 +13,21 @@ class GhostNodeWailaRequestPacketHandler : IMessageHandler<GhostNodeWailaRequest
     override fun onMessage(message: GhostNodeWailaRequestPacket, ctx: MessageContext?): GhostNodeWailaResponsePacket {
         val realCoord = Eln.ghostManager.getGhost(message.coord)?.observatorCoordonate
         var itemStack: ItemStack? = null
+        var type: Byte = GhostNodeWailaResponsePacket.UNKNOWN_TYPE
 
         if (realCoord != null) {
             val node = NodeManager.instance.getNodeFromCoordonate(realCoord) as? TransparentNode
             if (node != null) {
                 itemStack = node.element.descriptor.newItemStack()
+                type = GhostNodeWailaResponsePacket.TRANSPARENT_BLOCK_TYPE
+            }
+
+            val sixnode = NodeManager.instance.getNodeFromCoordonate(realCoord) as? SixNode
+            if (sixnode != null) {
+                type = GhostNodeWailaResponsePacket.SIXNODE_TYPE
             }
         }
 
-        return GhostNodeWailaResponsePacket(message.coord, realCoord ?: Coordonate(0, 0, 0 ,0), itemStack)
+        return GhostNodeWailaResponsePacket(message.coord, realCoord ?: Coordonate(0, 0, 0 ,0), itemStack, type)
     }
 }

--- a/src/main/java/mods/eln/packets/GhostNodeWailaResponsePacket.kt
+++ b/src/main/java/mods/eln/packets/GhostNodeWailaResponsePacket.kt
@@ -8,7 +8,14 @@ import net.minecraft.item.ItemStack
 
 class GhostNodeWailaResponsePacket(var coord: Coordonate = Coordonate(0, 0, 0 ,0),
                                    var realCoord: Coordonate = Coordonate(0, 0, 0 ,0),
-                                   var itemStack: ItemStack? = null): IMessage {
+                                   var itemStack: ItemStack? = null,
+                                   var type: Byte = UNKNOWN_TYPE): IMessage {
+
+    companion object {
+        val UNKNOWN_TYPE: Byte = 0
+        val TRANSPARENT_BLOCK_TYPE: Byte = 1
+        val SIXNODE_TYPE: Byte = 2
+    }
 
     private fun Coordonate.write(buf: ByteBuf?) {
         if (buf != null) {
@@ -32,11 +39,13 @@ class GhostNodeWailaResponsePacket(var coord: Coordonate = Coordonate(0, 0, 0 ,0
         coord.read(buf)
         realCoord.read(buf)
         itemStack = ByteBufUtils.readItemStack(buf)
+        type = buf?.readByte() ?: UNKNOWN_TYPE
     }
 
     override fun toBytes(buf: ByteBuf?) {
         coord.write(buf)
         realCoord.write(buf)
         ByteBufUtils.writeItemStack(buf, itemStack)
+        buf?.writeByte(type.toInt())
     }
 }

--- a/src/main/java/mods/eln/sixnode/modbusrtu/ModbusTcpServer.kt
+++ b/src/main/java/mods/eln/sixnode/modbusrtu/ModbusTcpServer.kt
@@ -3,7 +3,10 @@ package mods.eln.sixnode.modbusrtu
 import mods.eln.Eln
 import mods.eln.misc.Utils
 import java.io.OutputStream
-import java.net.*
+import java.net.BindException
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.Socket
 import java.nio.ByteBuffer
 import java.util.*
 
@@ -24,7 +27,7 @@ class ModbusTcpServer(port: Int = 1502) {
             } catch (e: BindException){
                 Utils.println("Exception while binding Modbus RTU Server. Modbus server disabled!")
                 server.close()
-                e.printStackTrace();
+                e.printStackTrace()
             }
             start()
         }
@@ -48,7 +51,7 @@ class ModbusTcpServer(port: Int = 1502) {
                     handle(socket.outputStream)
                     inputBuffer.flip()
                 } else {
-                    socket.close();
+                    socket.close()
                 }
             }
         }).start()
@@ -56,7 +59,7 @@ class ModbusTcpServer(port: Int = 1502) {
         private fun handle(output: OutputStream) {
             while (inputBuffer.hasRemaining()) {
                 val transactionId = inputBuffer.short
-                if (inputBuffer.short.equals(0)) {
+                if (inputBuffer.short == 0.toShort()) {
                     val remaining = inputBuffer.short
                     if (inputBuffer.remaining() >= remaining) {
                         val slaveAddress = inputBuffer.get()
@@ -86,10 +89,10 @@ class ModbusTcpServer(port: Int = 1502) {
                         output.write(response.array(), 0, response.remaining())
                         output.flush()
                     } else {
-                        return;
+                        return
                     }
                 } else {
-                    return;
+                    return
                 }
             }
         }
@@ -100,8 +103,8 @@ class ModbusTcpServer(port: Int = 1502) {
 
             try {
                 // TODO: Support for multiple coils...
-                if (quantity.equals(1)) {
-                    val value = slave.getCoil(address.toInt());
+                if (quantity == 1.toShort()) {
+                    val value = slave.getCoil(address.toInt())
                     response.put(0x01.toByte()).put(1.toByte()).put((if (value) 1 else 0).toByte())
                     return
                 }
@@ -115,8 +118,8 @@ class ModbusTcpServer(port: Int = 1502) {
 
             try {
                 // TODO: Support for multiple inputs...
-                if (quantity.equals(1)) {
-                    val value = slave.getInput(address.toInt());
+                if (quantity == 1.toShort()) {
+                    val value = slave.getInput(address.toInt())
                     response.put(0x02.toByte()).put(1.toByte()).put((if (value) 1 else 0).toByte())
                     return
                 }
@@ -169,7 +172,7 @@ class ModbusTcpServer(port: Int = 1502) {
 
     fun start() = Thread(Runnable {
         while (!server.isClosed) {
-            val socket = server.accept();
+            val socket = server.accept()
             if (socket != null) {
                 connections.add(ConnectionHandler(socket))
             }
@@ -189,7 +192,7 @@ class ModbusTcpServer(port: Int = 1502) {
     fun remove(slave: IModbusSlave) = slaves.remove(slave.slaveId)
 
     fun destroy() {
-        server.close();
+        server.close()
         connections.forEach { it.destroy() }
     }
 }


### PR DESCRIPTION
Not yet ready to merge, 

- [ ] Display the content for the represented sixnode block for ghost block.

@bloxgate: I would need to get the waila data for the represented sixnode [here](https://github.com/Electrical-Age/ElectricalAge/blob/bugfix/streetlight-waila/src/main/java/mods/eln/integration/waila/GhostNodeWailaProvider.kt#L67), but I do not know how to do it, any idea?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/electrical-age/electricalage/543)
<!-- Reviewable:end -->
