### PR TITLE
Might fix #525

### DIFF
--- a/src/main/java/mods/eln/sixnode/lampsocket/LightBlockEntity.java
+++ b/src/main/java/mods/eln/sixnode/lampsocket/LightBlockEntity.java
@@ -88,29 +88,6 @@ public class LightBlockEntity extends TileEntity {
 		Utils.println("Assert void replaceLight(int oldLight, int newLight)");
 	}*/
 
-	@Override
-	public void writeToNBT(NBTTagCompound nbt) {
-		super.writeToNBT(nbt);
-		int idx = 0;
-		for(LightHandle l : lightList) {
-			l.writeToNBT(nbt, "light" + idx);
-			idx++;
-		}
-		nbt.setInteger("lightNbr", lightList.size());
-	}
-	
-	@Override
-	public void readFromNBT(NBTTagCompound nbt) {
-		super.readFromNBT(nbt);
-		int size = nbt.getInteger("lightNbr");
-		for (int idx = 0; idx < size; idx++){
-			LightHandle l = new LightHandle();
-			l.readFromNBT(nbt, "light" + idx);
-			lightList.add(l);
-			idx++;
-		}
-	}
-	
 	/*
 	int getLight() {
 		int light = 0;


### PR DESCRIPTION
Light handles are not saved anymore to the map at all. I did not see any difference when playing (probably the first x frames are anyway not shown during startup), so I guess it is a simple non-intrusive fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/electrical-age/electricalage/555)
<!-- Reviewable:end -->
