### PR TITLE
Fixes turbine recipes, based on PR #571

### DIFF
--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -5544,41 +5544,27 @@ public class Eln {
 				" ME",
 				Character.valueOf('m'), findItemStack("Advanced Electrical Motor"),
 				Character.valueOf('M'), findItemStack("Advanced Machine Block"),
-				Character.valueOf('a'), "ingotAluminum",
+				Character.valueOf('a'), firstExistingOre("ingotAluminum", "ingotIron"),
 				Character.valueOf('E'), findItemStack("High Voltage Cable")
 		);
 		addRecipe(findItemStack("Steam Turbine"),
 				" a ",
 				"aAa",
 				" M ",
-				Character.valueOf('a'), "ingotAluminum",
-				Character.valueOf('A'), "blockAluminum",
+				Character.valueOf('a'), firstExistingOre("ingotAluminum", "ingotIron"),
+				Character.valueOf('A'), firstExistingOre("blockAluminum", "blockIron"),
 				Character.valueOf('M'), findItemStack("Advanced Machine Block")
 		);
-		// TODO(Baughn): Factor this into a builder.
-		if (OreDictionary.doesOreNameExist("ingotSteel") && OreDictionary.doesOreNameExist("blockSteel")) {
-			addRecipe(findItemStack("Gas Turbine"),
-					"msH",
-					"sSs",
-					" M ",
-					Character.valueOf('m'), findItemStack("Advanced Electrical Motor"),
-					Character.valueOf('H'), findItemStack("Copper Thermal Cable"),
-					Character.valueOf('s'), "ingotSteel",
-					Character.valueOf('S'), "blockSteel",
-					Character.valueOf('M'), findItemStack("Advanced Machine Block")
-			);
-		} else {
-			addRecipe(findItemStack("Gas Turbine"),
-					"msH",
-					"sSs",
-					" M ",
-					Character.valueOf('m'), findItemStack("Advanced Electrical Motor"),
-					Character.valueOf('H'), findItemStack("Copper Thermal Cable"),
-					Character.valueOf('s'), "ingotIron",
-					Character.valueOf('S'), "blockIron",
-					Character.valueOf('M'), findItemStack("Advanced Machine Block")
-			);
-		}
+		addRecipe(findItemStack("Gas Turbine"),
+				"msH",
+				"sSs",
+				" M ",
+				Character.valueOf('m'), findItemStack("Advanced Electrical Motor"),
+				Character.valueOf('H'), findItemStack("Copper Thermal Cable"),
+				Character.valueOf('s'), firstExistingOre("ingotSteel", "ingotIron"),
+				Character.valueOf('S'), firstExistingOre("blockSteel", "blockIron"),
+				Character.valueOf('M'), findItemStack("Advanced Machine Block")
+		);
 
 		addRecipe(findItemStack("Joint"),
 			"   ",
@@ -7385,6 +7371,16 @@ public class Eln {
 
 	public ItemStack findItemStack(String name) {
 		return findItemStack(name, 1);
+	}
+
+	public String firstExistingOre(String... oreNames) {
+		for (String oreName: oreNames) {
+			if (OreDictionary.doesOreNameExist(oreName)) {
+				return oreName;
+			}
+		}
+
+		return "";
 	}
 
 	public boolean isDevelopmentRun() {


### PR DESCRIPTION
Adds the method firstExistingOre that takes a list of ores from which it will return the first that is available.