### PR TITLE
Use atomic writing and backups for world saves

### DIFF
--- a/src/main/java/mods/eln/server/ServerEventListener.java
+++ b/src/main/java/mods/eln/server/ServerEventListener.java
@@ -18,6 +18,7 @@ import net.minecraftforge.event.world.WorldEvent.Load;
 import net.minecraftforge.event.world.WorldEvent.Save;
 import net.minecraftforge.event.world.WorldEvent.Unload;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.util.HashSet;
@@ -80,7 +81,9 @@ public class ServerEventListener {
             fileStream.close();
         } catch (Exception ex) {
             try {
-                FileInputStream fileStream = new FileInputStream(getEaWorldSaveName(e.world) + "back");
+                String name = getEaWorldSaveName(e.world) + ".bak";
+                FileInputStream fileStream = new FileInputStream(name);
+                System.out.println("Using BACKUP Electrical Age save: " + name);
                 NBTTagCompound nbt = CompressedStreamTools.readCompressed(fileStream);
                 readFromEaWorldNBT(nbt);
                 fileStream.close();
@@ -114,20 +117,21 @@ public class ServerEventListener {
             NBTTagCompound nbt = new NBTTagCompound();
             writeToEaWorldNBT(nbt, e.world.provider.dimensionId);
 
-//            File oldBackup = new File(getEaWorldSaveName(e.world) + "back");
-//            if (oldBackup.exists()) {
-//                oldBackup.delete();
-//            }
-//
-//            File oldSave = new File(getEaWorldSaveName(e.world));
-//            if (oldSave.exists()) {
-//                oldSave.renameTo(oldBackup);
-//            }
+            String worldSaveName = getEaWorldSaveName(e.world);
+            String tempSaveName = worldSaveName + ".tmp";
+            String backupSaveName = worldSaveName + ".bak";
+            File failedSave = new File(tempSaveName);
+            if (failedSave.exists()) {
+                failedSave.delete();
+            }
 
-            FileOutputStream fileStream = new FileOutputStream(getEaWorldSaveName(e.world));
+            FileOutputStream fileStream = new FileOutputStream(tempSaveName);
             CompressedStreamTools.writeCompressed(nbt, fileStream);
             fileStream.flush();
             fileStream.close();
+
+            new File(worldSaveName).renameTo(new File(backupSaveName));
+            new File(tempSaveName).renameTo(new File(worldSaveName));
         } catch (Exception ex) {
             ex.printStackTrace();
         }


### PR DESCRIPTION
Really, I've been told that this is the wrong way to do it, but I'm not going to change the way we do saving in the middle of 1.7.10.

That's for the port, I suppose.

Probably fixes #170.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/electrical-age/electricalage/658)
<!-- Reviewable:end -->
