### PR TITLE
Updating Transifex client used in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,6 @@ dist: trusty
 # Container-based infrastructure
 sudo: false
 
-# Install python dependencies in the home directory (no sudo access)
-# Transifex-client version 0.12.1 is required
-# See https://github.com/transifex/transifex-client/issues/113
-install:
-  - echo "Installing the Transifex client"
-  - pip install --user 'git+https://github.com/eliben/pycparser@release_v2.14'
-  - pip install --user 'requests[security]'
-  - pip install --user transifex-client
-
-env:
-  global:
-    # $TRANSIFEX_PASSWORD for Transifex (travis encrypt)
-    secure: c2LmAS3T90ZsRQCj5Qn2GUhWLU3DLumcD2jTMwTdnY8xwLPfsT8WOxPKq03aF/AnUH//67lRMToS5V4mYh/5sek7GX67+HMJBenQOuUjaSpcSK3/ik9hheTVt4M5i5Pu5JZrTe+D3LvGzukasho9jwmR/F0q6gmZYcfpkIKZ5QQ=
-
 # Caching Gradle
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/script/transifex.sh
+++ b/script/transifex.sh
@@ -4,11 +4,15 @@
 #
 # Generate and push the source language file to Transifex.
 # This script is called after every successful build on Travis CI.
-# It relies on $TRANSIFEX_PASSWORD being set in .travis.yml
-# The Transifex client must be installed.
 
 if [ "$TRAVIS_REPO_SLUG" == "Electrical-Age/ElectricalAge" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "develop" ]
 then
+  echo "Installing Transifex client"
+  pip install virtualenv
+  virtualenv ~/env
+  source ~/env/bin/activate
+  pip install transifex-client
+
   echo "Generating the latest language source file from the develop branch"
   ./gradlew updateMasterLanguageFile
 
@@ -16,9 +20,8 @@ then
   # Write .transifexrc file
   echo "[https://www.transifex.com]
 hostname = https://www.transifex.com
-password = $TRANSIFEX_PASSWORD
-token =
-username = metc" > ~/.transifexrc
+token = $TRANSIFEX_API_TOKEN
+username = $TRANSIFEX_USER" > ~/.transifexrc
   
   tx push --source --translations -l en_us --no-interactive --skip
 


### PR DESCRIPTION
Simplify a bit the logic to install the Transifex client and push the generated language file.
* Use API token set in Travis UI.
* Install the latest transifex Python client and do not compile from source any more. Do this only when needed and not for every build. Should speed-up the build time a bit.