### PR TITLE
Fixed brush bug

### DIFF
--- a/src/main/java/mods/eln/item/BrushDescriptor.kt
+++ b/src/main/java/mods/eln/item/BrushDescriptor.kt
@@ -57,7 +57,8 @@ class BrushDescriptor(name: String): GenericItemUsingDamageDescriptor(name) {
     }
 
     fun use(stack: ItemStack, entityPlayer: EntityPlayer): Boolean {
-        val creative = Minecraft.getMinecraft().thePlayer.capabilities.isCreativeMode
+
+        val creative = entityPlayer.capabilities.isCreativeMode
         var life = stack.tagCompound.getInteger("life")
         return if (creative || life != 0) {
             if (!creative) {


### PR DESCRIPTION
Fixes #845 

I tested, and you can now use the brush without crashing the server on multiplayer.

There are other parts of the file which also appear to be related to the client, but are not triggered by the server code, so it's *probably* fine