### PR TITLE
fixed sound bug 

### DIFF
--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -311,6 +311,8 @@ public class Eln {
     public static boolean noSymbols = false;
     public static boolean noVoltageBackground = false;
 
+    public static double maxSoundDistance = 16;
+
     @EventHandler
     public void preInit(FMLPreInitializationEvent event) {
 
@@ -461,6 +463,8 @@ public class Eln {
 
         Eln.noSymbols = config.get("general", "noSymbols", false).getBoolean();
         Eln.noVoltageBackground = config.get("general", "noVoltageBackground", false).getBoolean();
+
+        Eln.maxSoundDistance = config.get("debug", "maxSoundDistance", 16.0).getDouble();
 
         config.save();
 

--- a/src/main/java/mods/eln/sound/LoopedSoundManager.kt
+++ b/src/main/java/mods/eln/sound/LoopedSoundManager.kt
@@ -1,5 +1,6 @@
 package mods.eln.sound
 
+import mods.eln.Eln
 import net.minecraft.client.Minecraft
 
 class LoopedSoundManager(val updateInterval: Float = 0.5f) {
@@ -14,15 +15,33 @@ class LoopedSoundManager(val updateInterval: Float = 0.5f) {
 
     fun dispose() = loops.forEach { it.active = false }
 
+    // takes in two points and gets the squared distance delta between them
+    inline fun sqDistDelta(cx: Double, cy: Double, cz: Double, px: Double, py: Double, pz: Double) = (cx - px) * (cx - px) + (cy - py) * (cy - py) + (cz - pz) * (cz - pz)
+
     fun process(deltaT: Float) {
         remaining -= deltaT
         if (remaining <= 0) {
             val soundHandler = Minecraft.getMinecraft().soundHandler
             loops.forEach {
-                if (it.volume > 0 && it.pitch > 0 && !soundHandler.isSoundPlaying(it)) {
+                // add 0.5 to put the point in the center of the block making sounds
+                val cx = it.coord.x + 0.5
+                val cy = it.coord.y + 0.5
+                val cz = it.coord.z + 0.5
+                // get the player, and get the squared distance between the player and the block
+                val player = Minecraft.getMinecraft().thePlayer
+                val distDeltaSquared = sqDistDelta(cx, cy, cz, player.posX, player.posY, player.posZ)
+                // when comparing, compare distDeltaSquared to the square of the distance delta that you are trying to compare against.
+                if (it.volume > 0 && it.pitch > 0 && !soundHandler.isSoundPlaying(it) && distDeltaSquared < Eln.maxSoundDistance * Eln.maxSoundDistance) {
                     try {
                         soundHandler.playSound(it)
                     } catch (e: IllegalArgumentException) {
+                        System.out.println(e)
+                    }
+                }
+                if (distDeltaSquared >= Eln.maxSoundDistance * Eln.maxSoundDistance || it.volume == 0f || it.pitch == 0f) {
+                    try {
+                        soundHandler.stopSound(it)
+                    }catch (e: Exception) {
                         System.out.println(e)
                     }
                 }


### PR DESCRIPTION
I fixed the sound bug by setting limits on how far away looped sounds can be heard by the player.
The default is set to 16 blocks.
I also added a configuration option to increase/decrease distance:
```
debug {
    D:maxSoundDistance=16.0
}
```
I have found through rigorous testing that 16 blocks is about how far sounds travel normally. If you place _**a lot**_ of generators in a single area (you really have to be trying), you may need to lower this number to 8 to completely eliminate clipping.

Regardless, there will be no more intense lag caused by the sound engine (like in #820), if the default is left alone, since the sounds are unregistered from the sound manager. (I am pretty sure that the bug was caused by keeping all of the sounds loaded for the whole world, and continuing to register them to play at no volume)