### PR TITLE
Update zh_CN translators

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Code/models:
 Languages:
 
 - **bomdia** (it_IT)
-- **Ahtsm** (zh_CN)
+- **KLsz, aneBlack and Ahtsm** (zh_CN)
 - **dcbrwn** (ru_RU)
 - **XxCoolGamesxX** (es_ES - deprecated)
 


### PR DESCRIPTION
I'm KLsz, one of the main translators of zh_CN. I think KLsz and aneBlack are the main translators instead of Ahtsm.  

In Transifex, Ahtsm was the first Chinese translator of Eln, but he had quit before I got started, leaving a unfinished zh_CN branch. I was not sure whether he would be active again so I started my translation in the zh branch.  
You see, aneBlack and I translated most contents in the zh branch.  
![https://www.transifex.com/electrical-age/eln/translate/#zh/en_uslang/69182341](https://user-images.githubusercontent.com/12217600/48297410-0afbb080-e49f-11e8-9fd9-3adcdd2a0c61.png)  

And later skwdpy copied it to the zh-CN branch and covered the originally branch translated by Ahtsm.  
![80](https://user-images.githubusercontent.com/12217600/48297419-472f1100-e49f-11e8-9636-0f0257e21f5a.png)  

Because the zh branch was not finished, it was our translation that was used from r50, the first release that contains Chinese translation, to the newest 1.14.2.
![79 - 1](https://user-images.githubusercontent.com/12217600/48297487-41d2c600-e4a1-11e8-963c-c0bfda3e0a34.png)

Thanks.